### PR TITLE
Pre-commit and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-json
+        exclude: ^.vscode
+      - id: check-yaml
+      - id: trailing-whitespace
+        exclude: ^book
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3
+        args: ["--line-length=100"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+        args: ["--ignore=E203,E501,W503,E302,W391"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.782
+    hooks:
+      - id: mypy
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v0.13.1
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: (package-lock.json|.ipynb|poetry.lock|Makefile)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,4 @@ repos:
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
-        exclude: (package-lock.json|.ipynb|poetry.lock|Makefile)
+        exclude: (.ipynb|poetry.lock|.csv)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,66 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-04-03T17:08:39Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {},
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/examples/datasets/spam/SMSSpamCollection
+++ b/examples/datasets/spam/SMSSpamCollection
@@ -29,7 +29,7 @@ ham	Did you catch the bus ? Are you frying an egg ? Did you make a tea? Are you 
 ham	I'm back &amp; we're packing the car now, I'll let you know if there's room
 ham	Ahhh. Work. I vaguely remember that! What does it feel like? Lol
 ham	Wait that's still not all that clear, were you not sure about me being sarcastic or that that's why x doesn't want to live with us
-ham	Yeah he got in at 2 and was v apologetic. n had fallen out and she was actin like spoilt child and he got caught up in that. Till 2! But we won't go there! Not doing too badly cheers. You? 
+ham	Yeah he got in at 2 and was v apologetic. n had fallen out and she was actin like spoilt child and he got caught up in that. Till 2! But we won't go there! Not doing too badly cheers. You?
 ham	K tell me anything about you.
 ham	For fear of fainting with the of all that housework you just did? Quick have a cuppa
 spam	Thanks for your subscription to Ringtone UK your mobile will be charged £5/month Please confirm by replying YES or NO. If you reply NO you will not be charged
@@ -54,7 +54,7 @@ ham	K fyi x has a ride early tomorrow morning but he's crashing at our place ton
 ham	Wow. I never realized that you were so embarassed by your accomodations. I thought you liked it, since i was doing the best i could and you always seemed so happy about "the cave". I'm sorry I didn't and don't have more to give. I'm sorry i offered. I'm sorry your room was so embarassing.
 spam	SMS. ac Sptv: The New Jersey Devils and the Detroit Red Wings play Ice Hockey. Correct or Incorrect? End? Reply END SPTV
 ham	Do you know what Mallika Sherawat did yesterday? Find out now @  &lt;URL&gt;
-spam	Congrats! 1 year special cinema pass for 2 is yours. call 09061209465 now! C Suprman V, Matrix3, StarWars3, etc all 4 FREE! bx420-ip4-5we. 150pm. Dont miss out! 
+spam	Congrats! 1 year special cinema pass for 2 is yours. call 09061209465 now! C Suprman V, Matrix3, StarWars3, etc all 4 FREE! bx420-ip4-5we. 150pm. Dont miss out!
 ham	Sorry, I'll call later in meeting.
 ham	Tell where you reached
 ham	Yes..gauti and sehwag out of odi series.
@@ -79,7 +79,7 @@ ham	I like you peoples very much:) but am very shy pa.
 ham	Does not operate after  &lt;#&gt;  or what
 ham	Its not the same here. Still looking for a job. How much do Ta's earn there.
 ham	Sorry, I'll call later
-ham	K. Did you call me just now ah? 
+ham	K. Did you call me just now ah?
 ham	Ok i am on the way to home hi hi
 ham	You will be in the place of that man
 ham	Yup next stop.
@@ -89,7 +89,7 @@ ham	Yes I started to send requests to make it but pain came back so I'm back in 
 ham	I'm really not up to it still tonight babe
 ham	Ela kano.,il download, come wen ur free..
 ham	Yeah do! Don‘t stand to close tho- you‘ll catch something!
-ham	Sorry to be a pain. Is it ok if we meet another night? I spent late afternoon in casualty and that means i haven't done any of y stuff42moro and that includes all my time sheets and that. Sorry. 
+ham	Sorry to be a pain. Is it ok if we meet another night? I spent late afternoon in casualty and that means i haven't done any of y stuff42moro and that includes all my time sheets and that. Sorry.
 ham	Smile in Pleasure Smile in Pain Smile when trouble pours like Rain Smile when sum1 Hurts U Smile becoz SOMEONE still Loves to see u Smiling!!
 spam	Please call our customer service representative on 0800 169 6031 between 10am-9pm as you have WON a guaranteed £1000 cash or £5000 prize!
 ham	Havent planning to buy later. I check already lido only got 530 show in e afternoon. U finish work already?
@@ -115,14 +115,14 @@ ham	I'm ok wif it cos i like 2 try new things. But i scared u dun like mah. Cos 
 spam	GENT! We are trying to contact you. Last weekends draw shows that you won a £1000 prize GUARANTEED. Call 09064012160. Claim Code K52. Valid 12hrs only. 150ppm
 ham	Wa, ur openin sentence very formal... Anyway, i'm fine too, juz tt i'm eatin too much n puttin on weight...Haha... So anythin special happened?
 ham	As I entered my cabin my PA said, '' Happy B'day Boss !!''. I felt special. She askd me 4 lunch. After lunch she invited me to her apartment. We went there.
-spam	You are a winner U have been specially selected 2 receive £1000 or a 4* holiday (flights inc) speak to a live operator 2 claim 0871277810910p/min (18+) 
-ham	Goodo! Yes we must speak friday - egg-potato ratio for tortilla needed! 
+spam	You are a winner U have been specially selected 2 receive £1000 or a 4* holiday (flights inc) speak to a live operator 2 claim 0871277810910p/min (18+)
+ham	Goodo! Yes we must speak friday - egg-potato ratio for tortilla needed!
 ham	Hmm...my uncle just informed me that he's paying the school directly. So pls buy food.
 spam	PRIVATE! Your 2004 Account Statement for 07742676969 shows 786 unredeemed Bonus Points. To claim call 08719180248 Identifier Code: 45239 Expires
 spam	URGENT! Your Mobile No. was awarded £2000 Bonus Caller Prize on 5/9/03 This is our final try to contact U! Call from Landline 09064019788 BOX42WR29C, 150PPM
 ham	here is my new address -apples&pairs&all that malarky
 spam	Todays Voda numbers ending 7548 are selected to receive a $350 award. If you have a match please call 08712300220 quoting claim code 4041 standard rates app
-ham	I am going to sao mu today. Will be done only at 12 
+ham	I am going to sao mu today. Will be done only at 12
 ham	Ü predict wat time ü'll finish buying?
 ham	Good stuff, will do.
 ham	Just so that you know,yetunde hasn't sent money yet. I just sent her a text not to bother sending. So its over, you dont have to involve yourself in anything. I shouldn't have imposed anything on you in the first place so for that, i apologise.
@@ -167,12 +167,12 @@ spam	BangBabes Ur order is on the way. U SHOULD receive a Service Msg 2 download
 ham	I place all ur points on e cultures module already.
 spam	URGENT! We are trying to contact you. Last weekends draw shows that you have won a £900 prize GUARANTEED. Call 09061701939. Claim code S89. Valid 12hrs only
 ham	Hi frnd, which is best way to avoid missunderstding wit our beloved one's?
-ham	Great escape. I fancy the bridge but needs her lager. See you tomo 
+ham	Great escape. I fancy the bridge but needs her lager. See you tomo
 ham	Yes :)it completely in out of form:)clark also utter waste.
 ham	Sir, I need AXIS BANK account no and bank address.
-ham	Hmmm.. Thk sure got time to hop ard... Ya, can go 4 free abt... Muz call u to discuss liao... 
-ham	What time you coming down later? 
-ham	Bloody hell, cant believe you forgot my surname Mr . Ill give u a clue, its spanish and begins with m... 
+ham	Hmmm.. Thk sure got time to hop ard... Ya, can go 4 free abt... Muz call u to discuss liao...
+ham	What time you coming down later?
+ham	Bloody hell, cant believe you forgot my surname Mr . Ill give u a clue, its spanish and begins with m...
 ham	Well, i'm gonna finish my bath now. Have a good...fine night.
 ham	Let me know when you've got the money so carlos can make the call
 ham	U still going to the mall?
@@ -196,7 +196,7 @@ ham	It will stop on itself. I however suggest she stays with someone that will b
 ham	How are you doing? Hope you've settled in for the new school year. Just wishin you a gr8 day
 ham	Gud mrng dear hav a nice day
 ham	Did u got that persons story
-ham	is your hamster dead? Hey so tmr i meet you at 1pm orchard mrt? 
+ham	is your hamster dead? Hey so tmr i meet you at 1pm orchard mrt?
 ham	Hi its Kate how is your evening? I hope i can see you tomorrow for a bit but i have to bloody babyjontet! Txt back if u can. :) xxx
 ham	Found it, ENC  &lt;#&gt; , where you at?
 ham	I sent you  &lt;#&gt;  bucks
@@ -301,10 +301,10 @@ ham	I cant pick the phone right now. Pls send a message
 ham	Need a coffee run tomo?Can't believe it's that time of week already
 ham	Awesome, I remember the last time we got somebody high for the first time with diesel :V
 ham	Shit that is really shocking and scary, cant imagine for a second. Def up for night out. Do u think there is somewhere i could crash for night, save on taxi?
-ham	Oh and by the way you do have more food in your fridge! Want to go out for a meal tonight? 
+ham	Oh and by the way you do have more food in your fridge! Want to go out for a meal tonight?
 ham	He is a womdarfull actor
 spam	SMS. ac Blind Date 4U!: Rodds1 is 21/m from Aberdeen, United Kingdom. Check Him out http://img. sms. ac/W/icmb3cktz8r7!-4 no Blind Dates send HIDE
-ham	Yup... From what i remb... I think should be can book... 
+ham	Yup... From what i remb... I think should be can book...
 ham	Jos ask if u wana meet up?
 ham	Lol yes. Our friendship is hanging on a thread cause u won't buy stuff.
 spam	TheMob> Check out our newest selection of content, Games, Tones, Gossip, babes and sport, Keep your mobile fit and funky text WAP to 82468
@@ -320,7 +320,7 @@ ham	Not really dude, have no friends i'm afraid :(
 spam	December only! Had your mobile 11mths+? You are entitled to update to the latest colour camera mobile for Free! Call The Mobile Update Co FREE on 08002986906
 ham	Coffee cake, i guess...
 ham	Merry Christmas to you too babe, i love ya *kisses*
-ham	Hey... Why dont we just go watch x men and have lunch... Haha 
+ham	Hey... Why dont we just go watch x men and have lunch... Haha
 ham	cud u tell ppl im gona b a bit l8 cos 2 buses hav gon past cos they were full & im still waitin 4 1. Pete x
 ham	That would be great. We'll be at the Guild. Could meet on Bristol road or somewhere - will get in touch over weekend. Our plans take flight! Have a good week
 ham	No problem. How are you doing?
@@ -390,7 +390,7 @@ ham	Mm that time you dont like fun
 spam	4mths half price Orange line rental & latest camera phones 4 FREE. Had your phone 11mths ? Call MobilesDirect free on 08000938767 to update now! or2stoptxt
 ham	Yup having my lunch buffet now.. U eat already?
 ham	Huh so late... Fr dinner?
-ham	Hey so this sat are we going for the intro pilates only? Or the kickboxing too? 
+ham	Hey so this sat are we going for the intro pilates only? Or the kickboxing too?
 ham	Morning only i can ok.
 ham	Yes i think so. I am in office but my lap is in room i think thats on for the last few days. I didnt shut that down
 ham	Pick you up bout 7.30ish? What time are  and that going?
@@ -411,7 +411,7 @@ ham	Headin towards busetop
 ham	Message:some text missing* Sender:Name Missing* *Number Missing *Sent:Date missing *Missing U a lot thats y everything is missing sent via fullonsms.com
 ham	Come by our room at some point so we can iron out the plan for this weekend
 ham	Cos i want it to be your thing
-ham	Okies... I'll go yan jiu too... We can skip ard oso, go cine den go mrt one, blah blah blah... 
+ham	Okies... I'll go yan jiu too... We can skip ard oso, go cine den go mrt one, blah blah blah...
 ham	Bring home some Wendy =D
 spam	100 dating service cal;l 09064012103 box334sk38ch
 ham	Whatsup there. Dont u want to sleep
@@ -445,7 +445,7 @@ ham	Oic... I saw him too but i tot he din c me... I found a group liao...
 ham	Sorry, I'll call later
 ham	"HEY HEY WERETHE MONKEESPEOPLE SAY WE MONKEYAROUND! HOWDY GORGEOUS, HOWU DOIN? FOUNDURSELF A JOBYET SAUSAGE?LOVE JEN XXX"
 ham	Sorry, my battery died, I can come by but I'm only getting a gram for now, where's your place?
-ham	Well done, blimey, exercise, yeah, i kinda remember wot that is, hmm. 
+ham	Well done, blimey, exercise, yeah, i kinda remember wot that is, hmm.
 ham	I wont get concentration dear you know you are my mind and everything :-)
 ham	LOL ... Have you made plans for new years?
 ham	10 min later k...
@@ -517,7 +517,7 @@ spam	You are guaranteed the latest Nokia Phone, a 40GB iPod MP3 player or a £50
 ham	S:)no competition for him.
 spam	Boltblue tones for 150p Reply POLY# or MONO# eg POLY3 1. Cha Cha Slide 2. Yeah 3. Slow Jamz 6. Toxic 8. Come With Me or STOP 4 more tones txt MORE
 spam	Your credits have been topped up for http://www.bubbletext.com Your renewal Pin is tgxxrz
-ham	That way transport is less problematic than on sat night. By the way, if u want to ask  n  to join my bday, feel free. But need to know definite nos as booking on fri. 
+ham	That way transport is less problematic than on sat night. By the way, if u want to ask  n  to join my bday, feel free. But need to know definite nos as booking on fri.
 ham	Usually the person is unconscious that's in children but in adults they may just behave abnormally. I.ll call you now
 ham	But that's on ebay it might be less elsewhere.
 ham	Shall i come to get pickle
@@ -529,7 +529,7 @@ spam	Today's Offer! Claim ur £150 worth of discount vouchers! Text YES to 85023
 ham	Yes! How is a pretty lady like you single?
 spam	You will recieve your tone within the next 24hrs. For Terms and conditions please see Channel U Teletext Pg 750
 ham	Jay says that you're a double-faggot
-spam	PRIVATE! Your 2003 Account Statement for 07815296484 shows 800 un-redeemed S.I.M. points. Call 08718738001 Identifier Code 41782 Expires 18/11/04 
+spam	PRIVATE! Your 2003 Account Statement for 07815296484 shows 800 un-redeemed S.I.M. points. Call 08718738001 Identifier Code 41782 Expires 18/11/04
 ham	What Today-sunday..sunday is holiday..so no work..
 ham	Gudnite....tc...practice going on
 ham	I'll be late...
@@ -558,11 +558,11 @@ ham	O. Well uv causes mutations. Sunscreen is like essential thesedays
 ham	Having lunch:)you are not in online?why?
 ham	I know that my friend already told that.
 ham	Hi Princess! Thank you for the pics. You are very pretty. How are you?
-ham	Aiyo... U always c our ex one... I dunno abt mei, she haven reply... First time u reply so fast... Y so lucky not workin huh, got bao by ur sugardad ah...gee.. 
+ham	Aiyo... U always c our ex one... I dunno abt mei, she haven reply... First time u reply so fast... Y so lucky not workin huh, got bao by ur sugardad ah...gee..
 ham	Hi msg me:)i'm in office..
 ham	Thanx 4 e brownie it's v nice...
 ham	Geeeee ... I love you so much I can barely stand it
-spam	GENT! We are trying to contact you. Last weekends draw shows that you won a £1000 prize GUARANTEED. Call 09064012160. Claim Code K52. Valid 12hrs only. 150ppm 
+spam	GENT! We are trying to contact you. Last weekends draw shows that you won a £1000 prize GUARANTEED. Call 09064012160. Claim Code K52. Valid 12hrs only. 150ppm
 ham	Fuck babe ... I miss you already, you know ? Can't you let me send you some money towards your net ? I need you ... I want you ... I crave you ...
 ham	Ill call u 2mrw at ninish, with my address that icky American freek wont stop callin me 2 bad Jen k eh?
 ham	Oooh bed ridden ey? What are YOU thinking of?
@@ -573,7 +573,7 @@ ham	Yar lor wait 4 my mum 2 finish sch then have lunch lor... I whole morning st
 ham	Do you know where my lab goggles went
 ham	Can you open the door?
 ham	Waiting for your call.
-ham	Nope i waiting in sch 4 daddy... 
+ham	Nope i waiting in sch 4 daddy...
 spam	You have won ?1,000 cash or a ?2,000 prize! To claim, call09050000327
 ham	I'm tired of arguing with you about this week after week. Do what you want and from now on, i'll do the same.
 ham	Ü wait 4 me in sch i finish ard 5..
@@ -585,7 +585,7 @@ spam	We tried to contact you re your reply to our offer of 750 mins 150 textand 
 ham	my ex-wife was not able to have kids. Do you want kids one day?
 ham	So how's scotland. Hope you are not over showing your JJC tendencies. Take care. Live the dream
 ham	Tell them u have a headache and just want to use 1 hour of sick time.
-ham	I dun thk i'll quit yet... Hmmm, can go jazz ? Yogasana oso can... We can go meet em after our lessons den... 
+ham	I dun thk i'll quit yet... Hmmm, can go jazz ? Yogasana oso can... We can go meet em after our lessons den...
 ham	"Pete can you please ring meive hardly gotany credit"
 ham	Ya srsly better than yi tho
 ham	I'm in a meeting, call me later at
@@ -605,7 +605,7 @@ ham	Speaking of does he have any cash yet?
 ham	Be happy there. I will come after noon
 ham	Meet after lunch la...
 ham	TaKe CaRE n gET WeLL sOOn
-spam	XCLUSIVE@CLUBSAISAI 2MOROW 28/5 SOIREE SPECIALE ZOUK WITH NICHOLS FROM PARIS.FREE ROSES 2 ALL LADIES !!! info: 07946746291/07880867867 
+spam	XCLUSIVE@CLUBSAISAI 2MOROW 28/5 SOIREE SPECIALE ZOUK WITH NICHOLS FROM PARIS.FREE ROSES 2 ALL LADIES !!! info: 07946746291/07880867867
 ham	what I meant to say is cant wait to see u again getting bored of this bridgwater banter
 ham	Neva mind it's ok..
 ham	It's fine, imma get a drink or somethin. Want me to come find you?
@@ -640,7 +640,7 @@ ham	When ü login dat time... Dad fetching ü home now?
 ham	What will we do in the shower, baby?
 ham	I had askd u a question some hours before. Its answer
 ham	Well imma definitely need to restock before thanksgiving, I'll let you know when I'm out
-ham	 said kiss, kiss, i can't do the sound effects! He is a gorgeous man isn't he! Kind of person who needs a smile to brighten his day! 
+ham	 said kiss, kiss, i can't do the sound effects! He is a gorgeous man isn't he! Kind of person who needs a smile to brighten his day!
 ham	Probably gonna swing by in a wee bit
 ham	Ya very nice. . .be ready on thursday
 ham	Allo! We have braved the buses and taken on the trains and triumphed. I mean we‘re in b‘ham. Have a jolly good rest of week
@@ -675,7 +675,7 @@ spam	Get ur 1st RINGTONE FREE NOW! Reply to this msg with TONE. Gr8 TOP 20 tones
 ham	Ditto. And you won't have to worry about me saying ANYTHING to you anymore. Like i said last night, you do whatever you want and i'll do the same. Peace.
 ham	I've got  &lt;#&gt; , any way I could pick up?
 ham	I dont knw pa, i just drink milk..
-ham	Maybe?! Say hi to  and find out if  got his card. Great escape or wetherspoons? 
+ham	Maybe?! Say hi to  and find out if  got his card. Great escape or wetherspoons?
 ham	Piggy, r u awake? I bet u're still sleeping. I'm going 4 lunch now...
 ham	Cause I'm not freaky lol
 ham	Missed your call cause I was yelling at scrappy. Miss u. Can't wait for u to come home. I'm so lonely today.
@@ -753,7 +753,7 @@ spam	Do you realize that in about 40 years, we'll have thousands of old ladies r
 spam	You have an important customer service announcement from PREMIER.
 ham	Dont gimme that lip caveboy
 ham	When did you get to the library
-ham	Realy sorry-i don't recognise this number and am now confused :) who r u please?! 
+ham	Realy sorry-i don't recognise this number and am now confused :) who r u please?!
 ham	So why didnt you holla?
 ham	Cant think of anyone with * spare room off * top of my head
 ham	Faith makes things possible,Hope makes things work,Love makes things beautiful,May you have all three this Christmas!Merry Christmas!
@@ -770,7 +770,7 @@ ham	Sorry, I'll call later
 ham	I cant pick the phone right now. Pls send a message
 ham	Lol I know! They're so dramatic. Schools already closed for tomorrow. Apparently we can't drive in the inch of snow were supposed to get.
 ham	Not getting anywhere with this damn job hunting over here!
-ham	Lol! U drunkard! Just doing my hair at d moment. Yeah still up 4 tonight. Wats the plan? 
+ham	Lol! U drunkard! Just doing my hair at d moment. Yeah still up 4 tonight. Wats the plan?
 ham	idc get over here, you are not weaseling your way out of this shit twice in a row
 ham	I wil be there with in  &lt;#&gt;  minutes. Got any space
 ham	Just sleeping..and surfing
@@ -842,7 +842,7 @@ spam	Last chance 2 claim ur £150 worth of discount vouchers-Text YES to 85023 n
 ham	I luv u soo much u dont understand how special u r 2 me ring u 2morrow luv u xxx
 ham	Pls send me a comprehensive mail about who i'm paying, when and how much.
 ham	Our Prashanthettan's mother passed away last night. pray for her and family.
-spam	Urgent! call 09066350750 from your landline. Your complimentary 4* Ibiza Holiday or 10,000 cash await collection SAE T&Cs PO BOX 434 SK3 8WP 150 ppm 18+ 
+spam	Urgent! call 09066350750 from your landline. Your complimentary 4* Ibiza Holiday or 10,000 cash await collection SAE T&Cs PO BOX 434 SK3 8WP 150 ppm 18+
 ham	K.k:)when are you going?
 ham	Meanwhile in the shit suite: xavier decided to give us  &lt;#&gt;  seconds of warning that samantha was coming over and is playing jay's guitar to impress her or some shit. Also I don't think doug realizes I don't live here anymore
 ham	My stomach has been thru so much trauma I swear I just can't eat. I better lose weight.
@@ -902,7 +902,7 @@ spam	Your free ringtone is waiting to be collected. Simply text the password "MI
 ham	Probably money worries. Things are coming due and i have several outstanding invoices for work i did two and three months ago.
 ham	How is it possible to teach you. And where.
 ham	I wonder if your phone battery went dead ? I had to tell you, I love you babe
-ham	Lovely smell on this bus and it ain't tobacco... 
+ham	Lovely smell on this bus and it ain't tobacco...
 ham	We're all getting worried over here, derek and taylor have already assumed the worst
 ham	Hey what's up charles sorry about the late reply.
 spam	all the lastest from Stereophonics, Marley, Dizzee Racal, Libertines and The Strokes! Win Nookii games with Flirt!! Click TheMob WAP Bookmark or text WAP to 82468
@@ -917,7 +917,7 @@ ham	Call me da, i am waiting for your call.
 ham	I could ask carlos if we could get more if anybody else can chip in
 ham	Was actually about to send you a reminder today. Have a wonderful weekend
 ham	When people see my msgs, They think Iam addicted to msging... They are wrong, Bcoz They don\'t know that Iam addicted to my sweet Friends..!! BSLVYL
-ham	Hey you gave them your photo when you registered for driving ah? Tmr wanna meet at yck? 
+ham	Hey you gave them your photo when you registered for driving ah? Tmr wanna meet at yck?
 ham	Dont talk to him ever ok its my word.
 ham	When u wana see it then
 ham	On ma way to school. Can you pls send me ashley's number
@@ -946,7 +946,7 @@ ham	And also I've sorta blown him off a couple times recently so id rather not t
 ham	I sent my scores to sophas and i had to do secondary application for a few schools. I think if you are thinking of applying, do a research on cost also. Contact joke ogunrinde, her school is one me the less expensive ones
 ham	I cant wait to see you! How were the photos were useful? :)
 spam	Ur cash-balance is currently 500 pounds - to maximize ur cash-in now send GO to 86688 only 150p/msg. CC: 08718720201 PO BOX 114/14 TCR/W1
-ham	Hey i booked the kb on sat already... what other lessons are we going for ah? Keep your sat night free we need to meet and confirm our lodging 
+ham	Hey i booked the kb on sat already... what other lessons are we going for ah? Keep your sat night free we need to meet and confirm our lodging
 ham	Chk in ur belovd ms dict
 ham	Is that what time you want me to come?
 ham	Awesome, lemme know whenever you're around
@@ -974,7 +974,7 @@ ham	Haha awesome, omw back now then
 ham	Yup i thk so until e shop closes lor.
 ham	what is your account number?
 ham	Eh u send wrongly lar...
-ham	Hey no I ad a crap nite was borin without ya 2 boggy with me u boring biatch! Thanx but u wait til nxt time il ave ya 
+ham	Hey no I ad a crap nite was borin without ya 2 boggy with me u boring biatch! Thanx but u wait til nxt time il ave ya
 ham	Ok i shall talk to him
 ham	Dont hesitate. You know this is the second time she has had weakness like that. So keep i notebook of what she eat and did the day before or if anything changed the day before so that we can be sure its nothing
 ham	Hey you can pay. With salary de. Only  &lt;#&gt; .
@@ -996,7 +996,7 @@ ham	The Xmas story is peace.. The Xmas msg is love.. The Xmas miracle is jesus..
 ham	I can't, I don't have her number!
 ham	Change again... It's e one next to escalator...
 ham	Yetunde i'm in class can you not run water on it to make it ok. Pls now.
-ham	Not a lot has happened here. Feels very quiet. Beth is at her aunts and charlie is working lots. Just me and helen in at the mo. How have you been? 
+ham	Not a lot has happened here. Feels very quiet. Beth is at her aunts and charlie is working lots. Just me and helen in at the mo. How have you been?
 ham	Then ü wait 4 me at bus stop aft ur lect lar. If i dun c ü then i go get my car then come back n pick ü.
 ham	Aight will do, thanks again for comin out
 ham	No..but heard abt tat..
@@ -1044,7 +1044,7 @@ ham	I'm in class. Will holla later
 ham	Easy ah?sen got selected means its good..
 ham	Mmm thats better now i got a roast down me! id b better if i had a few drinks down me 2! Good indian?
 spam	We know someone who you know that fancies you. Call 09058097218 to find out who. POBox 6, LS15HB 150p
-ham	Come round, it's . 
+ham	Come round, it's .
 ham	Do 1 thing! Change that sentence into: "Because i want 2 concentrate in my educational career im leaving here.."
 spam	1000's flirting NOW! Txt GIRL or BLOKE & ur NAME & AGE, eg GIRL ZOE 18 to 8007 to join and get chatting!
 ham	I walked an hour 2 c u! doesnt that show I care y wont u believe im serious?
@@ -1089,7 +1089,7 @@ ham	I don't think he has spatula hands!
 ham	You can never do NOTHING
 spam	You are awarded a SiPix Digital Camera! call 09061221061 from landline. Delivery within 28days. T Cs Box177. M221BP. 2yr warranty. 150ppm. 16 . p p£3.99
 ham	Goodmorning today i am late for  &lt;DECIMAL&gt; min.
-spam	WIN URGENT! Your mobile number has been awarded with a £2000 prize GUARANTEED call 09061790121 from land line. claim 3030 valid 12hrs only 150ppm 
+spam	WIN URGENT! Your mobile number has been awarded with a £2000 prize GUARANTEED call 09061790121 from land line. claim 3030 valid 12hrs only 150ppm
 ham	Please da call me any mistake from my side sorry da. Pls da goto doctor.
 ham	Where r we meeting?
 ham	Well the weather in cali's great. But its complexities are great. You need a car to move freely, its taxes are outrageous. But all in all its a great place. The sad part is i missing home.
@@ -1125,7 +1125,7 @@ ham	Ok.ok ok..then..whats ur todays plan
 ham	Good morning princess! How are you?
 ham	Aiyar sorry lor forgot 2 tell u...
 spam	For taking part in our mobile survey yesterday! You can now have 500 texts 2 use however you wish. 2 get txts just send TXT to 80160 T&C www.txt43.com 1.50p
-ham	Not tonight mate. Catching up on some sleep. This is my new number by the way. 
+ham	Not tonight mate. Catching up on some sleep. This is my new number by the way.
 ham	Height of "Oh shit....!!" situation: A guy throws a luv letter on a gal but falls on her brothers head whos a gay,.;-):-D
 spam	Ur HMV Quiz cash-balance is currently £500 - to maximize ur cash-in now send HMV1 to 86688 only 150p/msg
 ham	So check your errors and if you had difficulties, do correction.
@@ -1175,7 +1175,7 @@ ham	Happy new years melody!
 ham	Ü dun need to pick ur gf?
 ham	Yay! You better not have told that to 5 other girls either.
 ham	Horrible u eat macs eat until u forgot abt me already rite... U take so long 2 reply. I thk it's more toot than b4 so b prepared. Now wat shall i eat?
-ham	Did he say how fantastic I am by any chance, or anything need a bigger life lift as losing the will 2 live, do you think I would be the first person 2 die from N V Q? 
+ham	Did he say how fantastic I am by any chance, or anything need a bigger life lift as losing the will 2 live, do you think I would be the first person 2 die from N V Q?
 ham	Just nw i came to hme da..
 ham	I'm outside islands, head towards hard rock and you'll run into me
 ham	To day class is there are no class.
@@ -1245,14 +1245,14 @@ ham	Nobody can decide where to eat and dad wants Chinese
 ham	No shoot me. I'm in the docs waiting room. :/
 ham	Now? I'm going out 4 dinner soon..
 ham	Hello which the site to download songs its urgent pls
-ham	I do know what u mean,  is the king of not havin credit! I'm goin2bed now. Night night sweet! Only1more sleep! 
+ham	I do know what u mean,  is the king of not havin credit! I'm goin2bed now. Night night sweet! Only1more sleep!
 ham	Horrible gal. Me in sch doing some stuff. How come u got mc?
 ham	HI HUN! IM NOT COMIN 2NITE-TELL EVERY1 IM SORRY 4 ME, HOPE U AVA GOODTIME!OLI RANG MELNITE IFINK IT MITE B SORTED,BUT IL EXPLAIN EVERYTHIN ON MON.L8RS.x
 ham	I call you later, don't have network. If urgnt, sms me.
 ham	Ummmmmaah Many many happy returns of d day my dear sweet heart.. HAPPY BIRTHDAY dear
 spam	Please CALL 08712402779 immediately as there is an urgent message waiting for you
 ham	Yeah like if it goes like it did with my friends imma flip my shit in like half an hour
-ham	Mum say we wan to go then go... Then she can shun bian watch da glass exhibition... 
+ham	Mum say we wan to go then go... Then she can shun bian watch da glass exhibition...
 ham	What your plan for pongal?
 ham	Just wait till end of march when el nino gets himself. Oh.
 ham	Not yet chikku..going to room nw, i'm in bus..
@@ -1289,7 +1289,7 @@ ham	Night has ended for another day, morning has come in a special way. May you 
 ham	What do you do, my dog ? Must I always wait till the end of your day to have word from you ? Did you run out of time on your cell already?
 ham	Happy new year to u too!
 ham	Hey...Great deal...Farm tour 9am to 5pm $95/pax, $50 deposit by 16 May
-ham	Eat jap done oso aft ur lect wat... Ü got lect at 12 rite... 
+ham	Eat jap done oso aft ur lect wat... Ü got lect at 12 rite...
 ham	Hey babe! I saw you came online for a second and then you disappeared, what happened ?
 ham	Da my birthdate in certificate is in april but real date is today. But dont publish it. I shall give you a special treat if you keep the secret. Any way thanks for the wishes
 ham	Happy birthday... May all ur dreams come true...
@@ -1305,7 +1305,7 @@ ham	FRAN I DECIDED 2 GO N E WAY IM COMPLETELY BROKE AN KNACKERED I GOT UP BOUT 3
 ham	I cant pick the phone right now. Pls send a message
 ham	Your right! I'll make the appointment right now.
 ham	Designation is software developer and may be she get chennai:)
-spam	Enjoy the jamster videosound gold club with your credits for 2 new videosounds+2 logos+musicnews! get more fun from jamster.co.uk! 16+only Help? call: 09701213186 
+spam	Enjoy the jamster videosound gold club with your credits for 2 new videosounds+2 logos+musicnews! get more fun from jamster.co.uk! 16+only Help? call: 09701213186
 spam	Get 3 Lions England tone, reply lionm 4 mono or lionp 4 poly. 4 more go 2 www.ringtones.co.uk, the original n best. Tones 3GBP network operator rates apply
 ham	I jokin oni lar.. Ü busy then i wun disturb ü.
 ham	Ok, be careful ! Don't text and drive !
@@ -1349,7 +1349,7 @@ ham	Is it ok if I stay the night here? Xavier has a sleeping bag and I'm getting
 ham	She doesnt need any test.
 ham	Nothing much, chillin at home. Any super bowl plan?
 spam	FREE2DAY sexy St George's Day pic of Jordan!Txt PIC to 89080 dont miss out, then every wk a saucy celeb!4 more pics c PocketBabe.co.uk 0870241182716 £3/wk
-ham	Bugis oso near wat... 
+ham	Bugis oso near wat...
 ham	Yo theres no class tmrw right?
 ham	Let Ur Heart Be Ur Compass Ur Mind Ur Map Ur Soul Ur Guide And U Will Never loose in world....gnun - Sent via WAY2SMS.COM
 ham	Goodnight, sleep well da please take care pa. Please.
@@ -1432,12 +1432,12 @@ spam	For sale - arsenal dartboard. Good condition but no doubles or trebles!
 ham	Don't look back at the building because you have no coat and i don't want you to get more sick. Just hurry home and wear a coat to the gym!!!
 ham	My painful personal thought- "I always try to keep everybody happy all the time. But nobody recognises me when i am alone"
 ham	Thanks for ve lovely wisheds. You rock
-ham	You intrepid duo you! Have a great time and see you both soon. 
+ham	You intrepid duo you! Have a great time and see you both soon.
 ham	I asked sen to come chennai and search for job.
-ham	Dad went out oredi... 
+ham	Dad went out oredi...
 ham	I jus hope its true that  missin me cos i'm really missin him! You haven't done anything to feel guilty about, yet.
 ham	Wat so late still early mah. Or we juz go 4 dinner lor. Aiya i dunno...
-ham	Arms fine, how's Cardiff and uni? 
+ham	Arms fine, how's Cardiff and uni?
 ham	In fact when do you leave? I think addie goes back to school tues or wed
 ham	Cool breeze... Bright sun... Fresh flower... Twittering birds... All these waiting to wish u: "GOODMORNING &amp; HAVE A NICE DAY" :)
 ham	Ya:)going for restaurant..
@@ -1448,9 +1448,9 @@ ham	I am in a marriage function
 ham	Looks like u wil b getting a headstart im leaving here bout 2.30ish but if u r desperate for my company I could head in earlier-we were goin to meet in rummer.
 ham	Don‘t give a flying monkeys wot they think and I certainly don‘t mind. Any friend of mine and all that!
 spam	As a registered optin subscriber ur draw 4 £100 gift voucher will be entered on receipt of a correct ans to 80062 Whats No1 in the BBC charts
-ham	say thanks2. 
+ham	say thanks2.
 ham	Msg me when rajini comes.
-ham	Ya! when are ü taking ure practical lessons? I start in june..  
+ham	Ya! when are ü taking ure practical lessons? I start in june..
 ham	That's good, because I need drugs
 ham	Stupid.its not possible
 ham	Can ü all decide faster cos my sis going home liao..
@@ -1496,7 +1496,7 @@ ham	How are you with moneY...as in to you...money aint a thing....how are you sh
 ham	It has everything to do with the weather. Keep extra warm. Its a cold but nothing serious. Pls lots of vitamin c
 ham	Hey gals.. Anyone of u going down to e driving centre tmr?
 ham	I'm always on yahoo messenger now. Just send the message to me and i.ll get it you may have to send it in the mobile mode sha but i.ll get it. And will reply.
-ham	I'm putting it on now. It should be ready for  &lt;TIME&gt; 
+ham	I'm putting it on now. It should be ready for  &lt;TIME&gt;
 ham	Time n Smile r the two crucial things in our life. Sometimes time makes us to forget smile, and sometimes someone's smile makes us to forget time gud noon
 spam	SMS. ac JSco: Energy is high, but u may not know where 2channel it. 2day ur leadership skills r strong. Psychic? Reply ANS w/question. End? Reply END JSCO
 ham	Host-based IDPS for linux systems.
@@ -1602,7 +1602,7 @@ ham	Yeah probably, I still gotta check out with leo
 ham	K.then any other special?
 ham	Carlos is taking his sweet time as usual so let me know when you and patty are done/want to smoke and I'll tell him to haul ass
 ham	Ok pa. Nothing problem:-)
-ham	Have you heard about that job? I'm going to that wildlife talk again tonight if u want2come. Its that2worzels and a wizzle or whatever it is?! 
+ham	Have you heard about that job? I'm going to that wildlife talk again tonight if u want2come. Its that2worzels and a wizzle or whatever it is?!
 ham	God picked up a flower and dippeditinaDEW, lovingly touched itwhichturnedinto u, and the he gifted tomeandsaid,THIS FRIEND IS 4U
 ham	When you came to hostel.
 ham	Ok no prob... I'll come after lunch then...
@@ -1652,7 +1652,7 @@ ham	ITS A LAPTOP TAKE IT WITH YOU.
 ham	I dont have any of your file in my bag..i was in work when you called me.i 'll tell you if i find anything in my room.
 ham	I wan but too early lei... Me outside now wun b home so early... Neva mind then...
 spam	For ur chance to win a £250 cash every wk TXT: ACTION to 80608. T's&C's www.movietrivia.tv custcare 08712405022, 1x150p/wk
-ham	I was at bugis juz now wat... But now i'm walking home oredi... Ü so late then reply... I oso saw a top dat i like but din buy... Where r ü now? 
+ham	I was at bugis juz now wat... But now i'm walking home oredi... Ü so late then reply... I oso saw a top dat i like but din buy... Where r ü now?
 ham	Wishing you and your family Merry "X" mas and HAPPY NEW Year in advance..
 ham	At 7 we will go ok na.
 ham	Yes I posted a couple of pics on fb. There's still snow outside too. I'm just waking up :)
@@ -1675,7 +1675,7 @@ spam	URGENT! We are trying to contact U. Todays draw shows that you have won a �
 spam	Monthly password for wap. mobsi.com is 391784. Use your wap phone not PC.
 ham	Nah dub but je still buff
 ham	Painful words- "I thought being Happy was the most toughest thing on Earth... But, the toughest is acting Happy with all unspoken pain inside.."
-ham	Yeah, that's fine! It's £6 to get in, is that ok? 
+ham	Yeah, that's fine! It's £6 to get in, is that ok?
 ham	Lol where do u come up with these ideas?
 ham	So many people seems to be special at first sight, But only very few will remain special to you till your last sight.. Maintain them till life ends.. Sh!jas
 ham	Today is "song dedicated day.." Which song will u dedicate for me? Send this to all ur valuable frnds but first rply me...
@@ -1693,7 +1693,7 @@ spam	Sunshine Quiz Wkly Q! Win a top Sony DVD player if u know which country the
 ham	I don't know but I'm raping dudes at poker
 ham	Weightloss! No more girl friends. Make loads of money on ebay or something. And give thanks to God.
 ham	Was gr8 to see that message. So when r u leaving? Congrats dear. What school and wat r ur plans.
-ham	Ü eatin later but i'm eatin wif my frens now lei... Ü going home first? 
+ham	Ü eatin later but i'm eatin wif my frens now lei... Ü going home first?
 ham	Finish already... Yar they keep saying i mushy... I so embarrassed ok...
 ham	Sorry man, my stash ran dry last night and I can't pick up more until sunday
 ham	Hai priya are you right. What doctor said pa. Where are you.
@@ -1721,7 +1721,7 @@ ham	As in missionary hook up, doggy hook up, standing...|
 ham	Then u better go sleep.. Dun disturb u liao.. U wake up then msg me lor..
 ham	Fighting with the world is easy, u either win or lose bt fightng with some1 who is close to u is dificult if u lose - u lose if u win - u still lose.
 ham	Am watching house – very entertaining – am getting the whole hugh laurie thing – even with the stick – indeed especially with the stick.
-ham	Thought praps you meant another one. Goodo! I'll look tomorrow 
+ham	Thought praps you meant another one. Goodo! I'll look tomorrow
 ham	Hi Jon, Pete here, Ive bin 2 Spain recently & hav sum dinero left, Bill said u or ur rents mayb interested in it, I hav 12,000pes, so around £48, tb, James.
 ham	There bold 2  &lt;#&gt; . Is that yours
 ham	You know there is. I shall speak to you in  &lt;#&gt;  minutes then
@@ -1729,7 +1729,7 @@ ham	"ALRITE HUNNY!WOT U UP 2 2NITE? DIDNT END UP GOIN DOWN TOWN JUS DA PUB INSTE
 ham	I went to project centre
 ham	As per your request 'Maangalyam (Alaipayuthe)' has been set as your callertune for all Callers. Press *9 to copy your friends Callertune
 ham	Lol yeah at this point I guess not
-ham	Doing project w frens lor. 
+ham	Doing project w frens lor.
 ham	Lol. Well quality aint bad at all so i aint complaining
 ham	K, can that happen tonight?
 spam	Hi, this is Mandy Sullivan calling from HOTMIX FM...you are chosen to receive £5000.00 in our Easter Prize draw.....Please telephone 09041940223 to claim before 29/03/05 or your prize will be transferred to someone else....
@@ -1803,9 +1803,9 @@ ham	excellent. I spent  &lt;#&gt;  years in the Air Force. Iraq and afghanistan.
 ham	I wanna watch that movie
 ham	Ok lor thanx... Ü in school?
 ham	I'm in class. Did you get my text.
-ham	The bus leaves at  &lt;#&gt; 
+ham	The bus leaves at  &lt;#&gt;
 ham	God bless.get good sleep my dear...i will pray!
-spam	Todays Voda numbers ending 1225 are selected to receive a £50award. If you have a match please call 08712300220 quoting claim code 3100 standard rates app 
+spam	Todays Voda numbers ending 1225 are selected to receive a £50award. If you have a match please call 08712300220 quoting claim code 3100 standard rates app
 ham	Do have a nice day today. I love you so dearly.
 ham	Aiyo a bit pai seh ü noe... Scared he dun rem who i am then die... Hee... But he become better lookin oredi leh...
 ham	Aight, I'll ask a few of my roommates
@@ -1849,9 +1849,9 @@ ham	Its on in engalnd! But telly has decided it won't let me watch it and mia an
 spam	FREE NOKIA Or Motorola with upto 12mths 1/2price linerental, 500 FREE x-net mins&100txt/mth FREE B'tooth*. Call Mobileupd8 on 08001950382 or call 2optout/D3WV
 ham	I dont want to hear philosophy. Just say what happen
 ham	You got job in wipro:)you will get every thing in life in 2 or 3 years.
-ham	Then cant get da laptop? My matric card wif ü lei... 
+ham	Then cant get da laptop? My matric card wif ü lei...
 ham	Dunno da next show aft 6 is 850. Toa payoh got 650.
-spam	This is the 2nd time we have tried 2 contact u. U have won the 750 Pound prize. 2 claim is easy, call 08718726970 NOW! Only 10p per min. BT-national-rate 
+spam	This is the 2nd time we have tried 2 contact u. U have won the 750 Pound prize. 2 claim is easy, call 08718726970 NOW! Only 10p per min. BT-national-rate
 ham	I just made some payments so dont have that much. Sorry. Would you want it fedex or the other way.
 ham	They did't play one day last year know even though they have very good team.. Like india.
 ham	K.:)you are the only girl waiting in reception ah?
@@ -1876,7 +1876,7 @@ spam	You have WON a guaranteed £1000 cash or a £2000 prize.To claim yr prize c
 spam	Would you like to see my XXX pics they are so hot they were nearly banned in the uk!
 spam	HMV BONUS SPECIAL 500 pounds of genuine HMV vouchers to be won. Just answer 4 easy questions. Play Now! Send HMV to 86688 More info:www.100percent-real.com
 ham	Watching tv now. I got new job :)
-ham	This pen thing is beyond a joke. Wont a Biro do? Don't do a masters as can't do this ever again! 
+ham	This pen thing is beyond a joke. Wont a Biro do? Don't do a masters as can't do this ever again!
 ham	I AM AT A PARTY WITH ALEX NICHOLS
 spam	U have a secret admirer who is looking 2 make contact with U-find out who they R*reveal who thinks UR so special-call on 09058094594
 ham	Just seeing your missed call my dear brother. Do have a gr8 day.
@@ -1885,7 +1885,7 @@ ham	Sorry, I can't help you on this.
 ham	Come to me, slave. Your doing it again ... Going into your shell and unconsciously avoiding me ... You are making me unhappy :-(
 ham	I love your ass! Do you enjoy doggy style? :)
 ham	I think asking for a gym is the excuse for lazy people. I jog.
-spam	Dear 0776xxxxxxx U've been invited to XCHAT. This is our final attempt to contact u! Txt CHAT to 86688 150p/MsgrcvdHG/Suite342/2Lands/Row/W1J6HL LDN 18yrs 
+spam	Dear 0776xxxxxxx U've been invited to XCHAT. This is our final attempt to contact u! Txt CHAT to 86688 150p/MsgrcvdHG/Suite342/2Lands/Row/W1J6HL LDN 18yrs
 spam	Urgent! Please call 09061743811 from landline. Your ABTA complimentary 4* Tenerife Holiday or £5000 cash await collection SAE T&Cs Box 326 CW25WX 150ppm
 ham	No. On the way home. So if not for the long dry spell the season would have been over
 ham	I gotta collect da car at 6 lei.
@@ -1903,16 +1903,16 @@ ham	And miss vday the parachute and double coins??? U must not know me very well
 ham	Sorry, I'll call later
 ham	My sister got placed in birla soft da:-)
 spam	Free entry in 2 a weekly comp for a chance to win an ipod. Txt POD to 80182 to get entry (std txt rate) T&C's apply 08452810073 for details 18+
-ham	Wah... Okie okie... Muz make use of e unlimited... Haha... 
+ham	Wah... Okie okie... Muz make use of e unlimited... Haha...
 ham	There're some people by mu, I'm at the table by lambda
 ham	And stop being an old man. You get to build snowman snow angels and snowball fights.
 ham	ELLO BABE U OK?
-ham	Hello beautiful r u ok? I've kinda ad a row wiv and he walked out the pub?? I wanted a night wiv u Miss u 
+ham	Hello beautiful r u ok? I've kinda ad a row wiv and he walked out the pub?? I wanted a night wiv u Miss u
 ham	Then u going ikea str aft dat?
 ham	Becoz its  &lt;#&gt;  jan whn al the post ofice is in holiday so she cn go fr the post ofice...got it duffer
 ham	Lol grr my mom is taking forever with my prescription. Pharmacy is like 2 minutes away. Ugh.
 ham	For real tho this sucks. I can't even cook my whole electricity is out. And I'm hungry.
-ham	You want to go? 
+ham	You want to go?
 spam	New TEXTBUDDY Chat 2 horny guys in ur area 4 just 25p Free 2 receive Search postcode or at gaytextbuddy.com. TXT ONE name to 89693. 08715500022 rpl Stop 2 cnl
 ham	Its not that time of the month nor mid of the time?
 ham	Fffff. Can you text kadeem or are you too far gone
@@ -1945,7 +1945,7 @@ ham	K...k:)why cant you come here and search job:)
 ham	I got lousy sleep. I kept waking up every 2 hours to see if my cat wanted to come in. I worry about him when its cold :(
 ham	Yeah, I'll leave in a couple minutes &amp; let you know when I get to mu
 ham	Can ü call me at 10:10 to make sure dat i've woken up...
-ham	Hey we can go jazz power yoga hip hop kb and yogasana 
+ham	Hey we can go jazz power yoga hip hop kb and yogasana
 ham	The battery is for mr adewale my uncle. Aka Egbon
 ham	I cant pick the phone right now. Pls send a message
 ham	Wait 2 min..stand at bus stop
@@ -1964,7 +1964,7 @@ ham	LOL that would be awesome payback.
 spam	it to 80488. Your 500 free text messages are valid until 31 December 2005.
 ham	Yes :)it completely in out of form:)clark also utter waste.
 ham	Honeybee Said: *I'm d Sweetest in d World* God Laughed &amp; Said: *Wait,U Havnt Met d Person Reading This Msg* MORAL: Even GOD Can Crack Jokes! GM+GN+GE+GN:)
-ham	Thanks. It was only from tescos but quite nice. All gone now. Speak soon 
+ham	Thanks. It was only from tescos but quite nice. All gone now. Speak soon
 ham	What's a feathery bowa? Is that something guys have that I don't know about?
 ham	Even i cant close my eyes you are in me our vava playing umma :-D
 ham	2 laptop... I noe infra but too slow lar... I wan fast one
@@ -1980,7 +1980,7 @@ spam	Reply to win £100 weekly! Where will the 2006 FIFA World Cup be held? Send
 ham	No I'm in the same boat. Still here at my moms. Check me out on yo. I'm half naked.
 ham	Shhhhh nobody is supposed to know!
 ham	Sorry, I'll call later
-ham	Sorry, I'll call later in meeting any thing related to trade please call Arul. &lt;#&gt; 
+ham	Sorry, I'll call later in meeting any thing related to trade please call Arul. &lt;#&gt;
 ham	Hey i will be late... i'm at amk. Need to drink tea or coffee
 ham	I wnt to buy a BMW car urgently..its vry urgent.but hv a shortage of  &lt;#&gt; Lacs.there is no source to arng dis amt. &lt;#&gt; lacs..thats my prob
 spam	Urgent! Please call 09061743810 from landline. Your ABTA complimentary 4* Tenerife Holiday or #5000 cash await collection SAE T&Cs Box 326 CW25WX 150 ppm
@@ -2014,7 +2014,7 @@ ham	Do whatever you want. You know what the rules are. We had a talk earlier thi
 ham	Beautiful Truth against Gravity.. Read carefully: "Our heart feels light when someone is in it.. But it feels very heavy when someone leaves it.." GOODMORNING
 spam	Great News! Call FREEFONE 08006344447 to claim your guaranteed £1000 CASH or £2000 gift. Speak to a live operator NOW!
 ham	Ambrith..madurai..met u in arun dha marrge..remembr?
-ham	Just re read it and I have no shame but tell me how he takes it and if he runs I will blame u 4 ever!! Not really 4 ever just a long time 
+ham	Just re read it and I have no shame but tell me how he takes it and if he runs I will blame u 4 ever!! Not really 4 ever just a long time
 ham	Princess, is your kitty shaved or natural?
 ham	Better than bb. If he wont use it, his wife will or them doctor
 ham	Ya it came a while ago
@@ -2024,7 +2024,7 @@ ham	I don't have anybody's number, I still haven't thought up a tactful way to a
 spam	U can WIN £100 of Music Gift Vouchers every week starting NOW Txt the word DRAW to 87066 TsCs www.ldew.com SkillGame,1Winaweek, age16.150ppermessSubscription
 ham	Is there any movie theatre i can go to and watch unlimited movies and just pay once?
 ham	U having lunch alone? I now so bored...
-ham	Yes obviously, but you are the eggs-pert and the potato head… Speak soon! 
+ham	Yes obviously, but you are the eggs-pert and the potato head… Speak soon!
 ham	Nah man, my car is meant to be crammed full of people
 ham	No got new job at bar in airport on satsgettin 4.47per hour but means no lie in! keep in touch
 ham	Kallis is ready for bat in 2nd innings
@@ -2037,7 +2037,7 @@ ham	Is avatar supposed to have subtoitles
 ham	Simply sitting and watching match in office..
 ham	You can jot down things you want to remember later.
 ham	Oh sorry please its over
-ham	Hey are we going for the lo lesson or gym? 
+ham	Hey are we going for the lo lesson or gym?
 ham	Dont pack what you can buy at any store.like cereals. If you must pack food, pack gari or something 9ja that you will miss.
 ham	You always make things bigger than they are
 ham	Ü dun wan to watch infernal affair?
@@ -2068,7 +2068,7 @@ ham	Cos daddy arranging time c wat time fetch ü mah...
 ham	Then. You are eldest know.
 ham	Who's there say hi to our drugdealer
 ham	Its hard to believe things like this. All can say lie but think twice before saying anything to me.
-spam	Eerie Nokia tones 4u, rply TONE TITLE to 8007 eg TONE DRACULA to 8007 Titles: GHOST, ADDAMSFA, MUNSTERS, EXORCIST, TWILIGHT www.getzed.co.uk POBox36504W45WQ 150p 
+spam	Eerie Nokia tones 4u, rply TONE TITLE to 8007 eg TONE DRACULA to 8007 Titles: GHOST, ADDAMSFA, MUNSTERS, EXORCIST, TWILIGHT www.getzed.co.uk POBox36504W45WQ 150p
 spam	Sexy Singles are waiting for you! Text your AGE followed by your GENDER as wither M or F E.G.23F. For gay men text your AGE followed by a G. e.g.23G.
 ham	Good night my dear.. Sleepwell&amp;Take care
 ham	That is wondarfull song
@@ -2135,14 +2135,14 @@ spam	Your B4U voucher w/c 27/03 is MARSMS. Log onto www.B4Utele.com for discount
 ham	Spoke with uncle john today. He strongly feels that you need to sacrifice to keep me here. He's going to call you. When he does, i beg you to just listen. Dont make any promises or make it clear things are not easy. And i need you to please let us work things out. As long as i keep expecting help, my creativity will be stifled so pls just keep him happy, no promises on your part.
 ham	If he started searching he will get job in few days.he have great potential and talent.
 ham	Carlos took a while (again), we leave in a minute
-ham	Well done and ! luv ya all 
+ham	Well done and ! luv ya all
 ham	Then why you came to hostel.
 ham	K still are you loving me.
 ham	But i juz remembered i gotta bathe my dog today..
 ham	After the drug she will be able to eat.
 ham	Alright took the morphine. Back in yo.
 ham	You see the requirements please
-ham	You stayin out of trouble stranger!!saw Dave the other day hes sorted now!still with me bloke when u gona get a girl MR!ur mum still Thinks we will get 2GETHA! 
+ham	You stayin out of trouble stranger!!saw Dave the other day hes sorted now!still with me bloke when u gona get a girl MR!ur mum still Thinks we will get 2GETHA!
 spam	FreeMsg: Hey - I'm Buffy. 25 and love to satisfy men. Home alone feeling randy. Reply 2 C my PIX! QlynnBV Help08700621170150p a msg Send stop to stop txts
 spam	Sunshine Hols. To claim ur med holiday send a stamped self address envelope to Drinks on Us UK, PO Box 113, Bray, Wicklow, Eire. Quiz Starts Saturday! Unsub Stop
 ham	So can collect ur laptop?
@@ -2155,7 +2155,7 @@ ham	Hi kindly give us back our documents which we submitted for loan from STAPAT
 ham	I dont have i shall buy one dear
 ham	Oh god i am happy to see your message after 3 days
 ham	What year. And how many miles.
-ham	Hey cutie. How goes it? Here in WALES its kinda ok. There is like hills and shit but i still avent killed myself. 
+ham	Hey cutie. How goes it? Here in WALES its kinda ok. There is like hills and shit but i still avent killed myself.
 ham	Sad story of a Man - Last week was my b'day. My Wife did'nt wish me. My Parents forgot n so did my Kids . I went to work. Even my Colleagues did not wish. As I entered my cabin my PA said, '' Happy B'day Boss !!''. I felt special. She askd me 4 lunch. After lunch she invited me to her apartment. We went there. She said,'' do u mind if I go into the bedroom for a minute ? '' ''OK'', I sed in a sexy mood. She came out 5 minuts latr wid a cake...n My Wife, My Parents, My Kidz, My Friends n My Colleagues. All screaming.. SURPRISE !! and I was waiting on the sofa.. ... ..... ' NAKED...!
 ham	I think you should go the honesty road. Call the bank tomorrow. Its the tough decisions that make us great people.
 spam	FREE for 1st week! No1 Nokia tone 4 ur mob every week just txt NOKIA to 87077 Get txting and tell ur mates. zed POBox 36504 W45WQ norm150p/tone 16+
@@ -2189,11 +2189,11 @@ ham	So is there anything specific I should be doing with regards to jaklin or wh
 ham	Oh god. I'm gonna Google nearby cliffs now.
 spam	FREE camera phones with linerental from 4.49/month with 750 cross ntwk mins. 1/2 price txt bundle deals also avble. Call 08001950382 or call2optout/J MF
 ham	Yup i shd haf ard 10 pages if i add figures... Ü all got how many pages?
-ham	Ooh, 4got, i'm gonna start belly dancing in moseley weds 6.30 if u want 2 join me, they have a cafe too. 
+ham	Ooh, 4got, i'm gonna start belly dancing in moseley weds 6.30 if u want 2 join me, they have a cafe too.
 ham	Thankyou so much for the call. I appreciate your care.
 ham	Congrats ! Treat pending.i am not on mail for 2 days.will mail once thru.Respect mother at home.check mails.
 ham	I called but no one pick up e phone. I ask both of them already they said ok.
-ham	Hi my email address has changed now it is 
+ham	Hi my email address has changed now it is
 ham	V-aluable. A-ffectionate. L-oveable. E-ternal. N-oble. T-ruthful. I-ntimate. N-atural. E-namous. Happy "VALENTINES DAY" in advance
 ham	Not much, just some textin'. How bout you?
 ham	Bring it if you got it
@@ -2208,7 +2208,7 @@ ham	Haha, my legs and neck are killing me and my amigos are hoping to end the ni
 spam	URGENT! Your mobile No 07xxxxxxxxx won a £2,000 bonus caller prize on 02/06/03! this is the 2nd attempt to reach YOU! call 09066362231 ASAP! BOX97N7QP, 150PPM
 ham	Usually the body takes care of it buy making sure it doesnt progress. Can we pls continue this talk on saturday.
 spam	URGENT!! Your 4* Costa Del Sol Holiday or £5000 await collection. Call 09050090044 Now toClaim. SAE, TC s, POBox334, Stockport, SK38xh, Cost£1.50/pm, Max10mins
-ham	Hmm well, night night 
+ham	Hmm well, night night
 ham	Just wanted to say holy shit you guys weren't kidding about this bud
 ham	Just gettin a bit arty with my collages at the mo, well tryin 2 ne way! Got a roast in a min lovely i shall enjoy that!
 ham	This is one of the days you have a billion classes, right?
@@ -2309,7 +2309,7 @@ ham	Aight that'll work, thanks
 spam	WIN a year supply of CDs 4 a store of ur choice worth £500 & enter our £100 Weekly draw txt MUSIC to 87066 Ts&Cs www.Ldew.com.subs16+1win150ppmx3
 spam	Moby Pub Quiz.Win a £100 High Street prize if u know who the new Duchess of Cornwall will be? Txt her first name to 82277.unsub STOP £1.50 008704050406 SP Arrow
 ham	I have 2 sleeping bags, 1 blanket and paper and  phone details. Anything else?
-spam	You have won a Nokia 7250i. This is what you get when you win our FREE auction. To take part send Nokia to 86021 now. HG/Suite342/2Lands Row/W1JHL 16+ 
+spam	You have won a Nokia 7250i. This is what you get when you win our FREE auction. To take part send Nokia to 86021 now. HG/Suite342/2Lands Row/W1JHL 16+
 spam	Congratulations! Thanks to a good friend U have WON the £2,000 Xmas prize. 2 claim is easy, just call 08718726971 NOW! Only 10p per minute. BT-national-rate.
 spam	tddnewsletter@emc1.co.uk (More games from TheDailyDraw) Dear Helen, Dozens of Free Games - with great prizesWith..
 ham	So what do you guys do.
@@ -2350,7 +2350,7 @@ ham	But i dint slept in afternoon.
 ham	That seems unnecessarily affectionate
 ham	Yar else i'll thk of all sorts of funny things.
 ham	You will be in the place of that man
-spam	Download as many ringtones as u like no restrictions, 1000s 2 choose. U can even send 2 yr buddys. Txt Sir to 80082 £3 
+spam	Download as many ringtones as u like no restrictions, 1000s 2 choose. U can even send 2 yr buddys. Txt Sir to 80082 £3
 ham	Thats cool. How was your day?
 spam	Please CALL 08712402902 immediately as there is an urgent message waiting for you.
 ham	R we going with the  &lt;#&gt;  bus?
@@ -2369,7 +2369,7 @@ spam	Tone Club: Your subs has now expired 2 re-sub reply MONOC 4 monos or POLYC 
 ham	V nice! Off 2 sheffield tom 2 air my opinions on categories 2 b used 2 measure ethnicity in next census. Busy transcribing. :-)
 ham	If you r @ home then come down within 5 min
 ham	A Boy loved a gal. He propsd bt she didnt mind. He gv lv lttrs, Bt her frnds threw thm. Again d boy decided 2 aproach d gal , dt time a truck was speeding towards d gal. Wn it was about 2 hit d girl,d boy ran like hell n saved her. She asked 'hw cn u run so fast?' D boy replied "Boost is d secret of my energy" n instantly d girl shouted "our energy" n Thy lived happily 2gthr drinking boost evrydy Moral of d story:- I hv free msgs:D;): gud ni8
-ham	That day ü say ü cut ur hair at paragon, is it called hair sense? Do ü noe how much is a hair cut? 
+ham	That day ü say ü cut ur hair at paragon, is it called hair sense? Do ü noe how much is a hair cut?
 ham	Hmm, too many of them unfortunately... Pics obviously arent hot cakes. Its kinda fun tho
 ham	Watching tv lor... Y she so funny we bluff her 4 wat. Izzit because she thk it's impossible between us?
 spam	XMAS Prize draws! We are trying to contact U. Todays draw shows that you have won a £2000 prize GUARANTEED. Call 09058094565 from land line. Valid 12hrs only
@@ -2392,7 +2392,7 @@ ham	Boo. How's things? I'm back at home and a little bored already :-(
 ham	First has she gained more than  &lt;#&gt; kg since she took in. Second has she done the blood sugar tests. If she has and its ok and her blood pressure is within normal limits then no worries
 ham	PICK UR FONE UP NOW U DUMB?
 ham	Thanks da thangam, i feel very very happy dear. I also miss you da.
-ham	Okey doke. I'm at home, but not dressed cos laying around ill! Speak to you later bout times and stuff. 
+ham	Okey doke. I'm at home, but not dressed cos laying around ill! Speak to you later bout times and stuff.
 ham	I don't run away frm u... I walk slowly &amp; it kills me that u don't care enough to stop me...
 ham	Babe, I'm back ... Come back to me ...
 ham	Well you told others you'd marry them...
@@ -2416,7 +2416,7 @@ ham	Lol please do. Actually send a pic of yourself right now. I wanna see. Pose 
 ham	O was not into fps then.
 ham	Huh means computational science... Y they like dat one push here n there...
 ham	Could you not read me, my Love ? I answered you
-ham	Oh... Lk tt den we take e one tt ends at cine lor... Dun wan yogasana oso can... 
+ham	Oh... Lk tt den we take e one tt ends at cine lor... Dun wan yogasana oso can...
 ham	Madam,regret disturbance.might receive a reference check from DLF Premarica.kindly be informed.Rgds,Rakhesh,Kerala.
 spam	SMS SERVICES For your inclusive text credits pls gotto www.comuk.net login 3qxj9 unsubscribe with STOP no extra charge help 08702840625 comuk.220cm2 9AE
 ham	Oic... Then better quickly go bathe n settle down...
@@ -2437,10 +2437,10 @@ ham	Uncle boye. I need movies oh. Guide me. Plus you know torrents are not parti
 ham	Oh ya ya. I remember da. .
 ham	Btw regarding that we should really try to see if anyone else can be our 4th guy before we commit to a random dude
 spam	For ur chance to win £250 cash every wk TXT: PLAY to 83370. T's&C's www.music-trivia.net custcare 08715705022, 1x150p/wk.
-ham	I not busy juz dun wan 2 go so early.. Hee.. 
+ham	I not busy juz dun wan 2 go so early.. Hee..
 ham	Rightio. 11.48 it is then. Well arent we all up bright and early this morning.
 ham	Great. I'm in church now, will holla when i get out
-ham	Back in brum! Thanks for putting us up and keeping us all and happy. See you soon 
+ham	Back in brum! Thanks for putting us up and keeping us all and happy. See you soon
 ham	I donno if they are scorable
 ham	&lt;#&gt;  great loxahatchee xmas tree burning update: you can totally see stars here
 ham	Yes but i dont care! I need you bad, princess!
@@ -2601,7 +2601,7 @@ ham	Okie... Thanx...
 ham	Gosh that , what a pain. Spose I better come then.
 ham	As usual..iam fine, happy &amp; doing well..:)
 ham	Okie
-ham	So when you gonna get rimac access 
+ham	So when you gonna get rimac access
 ham	"Im at arestaurant eating squid! i will be out about 10:30 wanna dosomething or is that to late?"
 ham	You call times job today ok umma and ask them to speed up
 ham	"HELLO U.CALL WEN U FINISH WRK.I FANCY MEETIN UP WIV U ALL TONITE AS I NEED A BREAK FROM DABOOKS. DID 4 HRS LAST NITE+2 TODAY OF WRK!"
@@ -2683,20 +2683,20 @@ ham	Solve d Case : A Man Was Found Murdered On  &lt;DECIMAL&gt; . &lt;#&gt;  Aft
 ham	I'm on da bus going home...
 ham	I got a call from a landline number. . . I am asked to come to anna nagar . . . I will go in the afternoon
 ham	I'm okay. Chasing the dream. What's good. What are you doing next.
-ham	Yupz... I've oredi booked slots 4 my weekends liao... 
+ham	Yupz... I've oredi booked slots 4 my weekends liao...
 spam	URGENT! We are trying to contact U. Todays draw shows that you have won a £800 prize GUARANTEED. Call 09050003091 from land line. Claim C52. Valid 12hrs only
 ham	There r many model..sony ericson also der.. &lt;#&gt; ..it luks good bt i forgot modl no
 ham	Okie
 ham	Yes I know the cheesy songs from frosty the snowman :)
 ham	Ya ok, vikky vl c witin  &lt;#&gt; mins and il reply u..
-spam	sports fans - get the latest sports news str* 2 ur mobile 1 wk FREE PLUS a FREE TONE Txt SPORT ON to 8007 www.getzed.co.uk 0870141701216+ norm 4txt/120p 
+spam	sports fans - get the latest sports news str* 2 ur mobile 1 wk FREE PLUS a FREE TONE Txt SPORT ON to 8007 www.getzed.co.uk 0870141701216+ norm 4txt/120p
 ham	Hey tmr meet at bugis 930 ?
 spam	Urgent Urgent! We have 800 FREE flights to Europe to give away, call B4 10th Sept & take a friend 4 FREE. Call now to claim on 09050000555. BA128NNFWFLY150ppm
 ham	All these nice new shirts and the only thing I can wear them to is nudist themed ;_; you in mu?
 ham	Hey sexy buns! What of that day? No word from you this morning on YM ... :-( ... I think of you
 ham	And whenever you and i see we can still hook up too.
 ham	Nope but i'm going home now then go pump petrol lor... Like going 2 rain soon...
-ham	Can you use foreign stamps for whatever you send them off for? 
+ham	Can you use foreign stamps for whatever you send them off for?
 spam	FROM 88066 LOST £12 HELP
 ham	Oh baby of the house. How come you dont have any new pictures on facebook
 ham	Feb  &lt;#&gt;  is "I LOVE U" day. Send dis to all ur "VALUED FRNDS" evn me. If 3 comes back u'll gt married d person u luv! If u ignore dis u will lose ur luv 4 Evr
@@ -2751,7 +2751,7 @@ ham	Send his number and give reply tomorrow morning for why you said that to him
 ham	You said not now. No problem. When you can. Let me know.
 ham	Ok but tell me half an hr b4 u come i need 2 prepare.
 ham	Play w computer? Aiyah i tok 2 u lor?
-ham	Sat right? Okay thanks... 
+ham	Sat right? Okay thanks...
 ham	Derp. Which is worse, a dude who always wants to party or a dude who files a complaint about the three drug abusers he lives with
 ham	Ok Chinese food on its way. When I get fat you're paying for my lipo.
 ham	We r outside already.
@@ -2806,7 +2806,7 @@ spam	FreeMsg>FAV XMAS TONES!Reply REAL
 ham	Lil fever:) now fine:)
 ham	I think it's all still in my car
 ham	Can a not?
-spam	December only! Had your mobile 11mths+? You are entitled to update to the latest colour camera mobile for Free! Call The Mobile Update Co FREE on 08002986906 
+spam	December only! Had your mobile 11mths+? You are entitled to update to the latest colour camera mobile for Free! Call The Mobile Update Co FREE on 08002986906
 ham	Yes princess! I want to catch you with my big strong hands...
 ham	Oh yeah I forgot. U can only take 2 out shopping at once.
 ham	Mm so you asked me not to call radio
@@ -2856,13 +2856,13 @@ ham	I doubt you could handle 5 times per night in any case...
 ham	Haha... Hope ü can hear the receipt sound... Gd luck!
 ham	Your gonna be the death if me. I'm gonna leave a note that says its all robs fault. Avenge me.
 ham	Japanese Proverb: If one Can do it, U too Can do it, If none Can do it,U must do it Indian version: If one Can do it, LET HIM DO it.. If none Can do it,LEAVE it!! And finally Kerala version: If one can do it, Stop him doing it.. If none can do it, Make a strike against it ...
-ham	Today i'm not workin but not free oso... Gee... Thgt u workin at ur fren's shop ? 
+ham	Today i'm not workin but not free oso... Gee... Thgt u workin at ur fren's shop ?
 ham	In life when you face choices Just toss a coin not becoz its settle the question But while the coin in the air U will know what your heart is hoping for. Gudni8
 ham	Do you know why god created gap between your fingers..? So that, One who is made for you comes &amp; fills those gaps by holding your hand with LOVE..!
 ham	I want to be there so i can kiss you and feel you next to me
 ham	I am not at all happy with what you saying or doing
 spam	Adult 18 Content Your video will be with you shortly
-ham	Ok that would b lovely, if u r sure. Think about wot u want to do, drinkin, dancin, eatin, cinema, in, out, about... Up to u! Wot about ? 
+ham	Ok that would b lovely, if u r sure. Think about wot u want to do, drinkin, dancin, eatin, cinema, in, out, about... Up to u! Wot about ?
 ham	What I'm saying is if you haven't explicitly told nora I know someone I'm probably just not gonna bother
 ham	He says hi and to get your ass back to south tampa (preferably at a kegger)
 ham	Smith waste da.i wanna gayle.
@@ -2871,7 +2871,7 @@ ham	Aight, tomorrow around  &lt;#&gt;  it is
 ham	House-Maid is the murderer, coz the man was murdered on  &lt;#&gt; th January.. As public holiday all govt.instituitions are closed,including post office..understand?
 spam	YOUR CHANCE TO BE ON A REALITY FANTASY SHOW call now = 08707509020 Just 20p per min NTT Ltd, PO Box 1327 Croydon CR9 5WB 0870 is a national = rate call.
 ham	I actually did for the first time in a while. I went to bed not too long after i spoke with you. Woke up at 7. How was your night?
-ham	See you there! 
+ham	See you there!
 ham	I dont understand your message.
 ham	Crucify is c not s. You should have told me earlier.
 ham	Idk. You keep saying that you're not, but since he moved, we keep butting heads over freedom vs. responsibility. And i'm tired. I have so much other shit to deal with that i'm barely keeping myself together once this gets added to it.
@@ -2941,7 +2941,7 @@ ham	Hey i've booked the pilates and yoga lesson already... Haha
 ham	Are you ok. What happen to behave like this
 spam	You have 1 new message. Please call 08712400200.
 ham	My supervisor find 4 me one lor i thk his students. I havent ask her yet. Tell u aft i ask her.
-ham	Hello. No news on job, they are making me wait a fifth week! Yeah im up for some woozles and weasels... In exeter still, but be home about 3. 
+ham	Hello. No news on job, they are making me wait a fifth week! Yeah im up for some woozles and weasels... In exeter still, but be home about 3.
 ham	No message..no responce..what happend?
 spam	We currently have a message awaiting your collection. To collect your message just call 08718723815.
 ham	Hey babe, sorry i didn't get sooner. Gary can come and fix it cause he thinks he knows what it is but he doesn't go as far a Ptbo and he says it will cost  &lt;#&gt;  bucks. I don't know if it might be cheaper to find someone there ? We don't have any second hand machines at all right now, let me know what you want to do babe
@@ -2983,7 +2983,7 @@ ham	What u mean u almost done? Done wif sleeping? But i tot u going to take a na
 ham	7 wonders in My WORLD 7th You 6th Ur style 5th Ur smile 4th Ur Personality 3rd Ur Nature 2nd Ur SMS and 1st "Ur Lovely Friendship"... good morning dear
 ham	Tonight? Yeah, I'd be down for that
 ham	What should i eat fo lunch senor
-ham	He said that he had a right giggle when he saw u again! You would possibly be the first person2die from NVQ, but think how much you could for! 
+ham	He said that he had a right giggle when he saw u again! You would possibly be the first person2die from NVQ, but think how much you could for!
 ham	No break time one... How... I come out n get my stuff fr ü?
 spam	Reply to win £100 weekly! What professional sport does Tiger Woods play? Send STOP to 87239 to end service
 ham	I'm there and I can see you, but you can't see me ? Maybe you should reboot ym ? I seen the buzz
@@ -3011,7 +3011,7 @@ spam	Loan for any purpose £500 - £75,000. Homeowners + Tenants welcome. Have y
 spam	Update_Now - 12Mths Half Price Orange line rental: 400mins...Call MobileUpd8 on 08000839402 or call2optout=J5Q
 ham	Imagine Life WITHOUT ME... see.. How fast u are searching me?Don't worry.. l'm always there To disturb U.. Goodnoon..:)
 ham	Hm good morning, headache anyone? :-)
-ham	Yeah no probs - last night is obviously catching up with you... Speak soon 
+ham	Yeah no probs - last night is obviously catching up with you... Speak soon
 spam	FREE UNLIMITED HARDCORE PORN direct 2 your mobile Txt PORN to 69200 & get FREE access for 24 hrs then chrgd@50p per day txt Stop 2exit. This msg is free
 ham	I might go 2 sch. Yar at e salon now v boring.
 ham	 &lt;#&gt;  mins but i had to stop somewhere first.
@@ -3030,7 +3030,7 @@ ham	You still at the game?
 ham	You have got tallent but you are wasting.
 ham	What is your record for one night? :)
 ham	Also sir, i sent you an email about how to log into the usc payment portal. I.ll send you another message that should explain how things are back home. Have a great weekend.
-ham	 gonna let me know cos comes bak from holiday that day.  is coming. Don't4get2text me  number. 
+ham	 gonna let me know cos comes bak from holiday that day.  is coming. Don't4get2text me  number.
 ham	Jokin only lar... :-) depends on which phone my father can get lor...
 ham	Aight, lemme know what's up
 ham	Get ready for  &lt;#&gt;  inches of pleasure...
@@ -3046,7 +3046,7 @@ ham	Your bill at 3 is £33.65 so thats not bad!
 ham	Let me know how it changes in the next 6hrs. It can even be appendix but you are out of that age range. However its not impossible. So just chill and let me know in 6hrs
 ham	Hello, yeah i've just got out of the bath and need to do my hair so i'll come up when i'm done, yeah?
 ham	So how's the weather over there?
-ham	Ok. Not much to do here though. H&M Friday, cant wait. Dunno wot the hell im gonna do for another 3 weeks! Become a slob- oh wait, already done that! 
+ham	Ok. Not much to do here though. H&M Friday, cant wait. Dunno wot the hell im gonna do for another 3 weeks! Become a slob- oh wait, already done that!
 ham	Die... Now i have e toot fringe again...
 ham	Lol they don't know about my awesome phone. I could click delete right now if I want.
 ham	Ok
@@ -3084,7 +3084,7 @@ ham	Have a great trip to India. And bring the light to everyone not just with th
 ham	And very importantly, all we discuss is between u and i only.
 ham	K..k:)how about your training process?
 ham	Ok lor. I ned 2 go toa payoh 4 a while 2 return smth u wan 2 send me there or wat?
-ham	In da car park 
+ham	In da car park
 ham	I wish that I was with you. Holding you tightly. Making you see how important you are. How much you mean to me ... How much I need you ... In my life ...
 ham	So i asked how's anthony. Dad. And your bf
 ham	'Wnevr i wana fal in luv vth my books, My bed fals in luv vth me..!'' . Yen madodu, nav pretsorginta, nammanna pretsovru important alwa....!!:) Gud eveB-).
@@ -3182,7 +3182,7 @@ ham	Does cinema plus drink appeal tomo? * Is a fr thriller by director i like on
 ham	There the size of elephant tablets & u shove um up ur ass!!
 ham	So many people seems to be special at first sight, But only very few will remain special to you till your last sight.. Maintain them till life ends.. take cr da
 ham	My Parents, My Kidz, My Friends n My Colleagues. All screaming.. SURPRISE !! and I was waiting on the sofa.. ... ..... ' NAKED...!
-ham	Dunno i juz askin cos i got a card got 20% off 4 a salon called hair sense so i tot it's da one ü cut ur hair. 
+ham	Dunno i juz askin cos i got a card got 20% off 4 a salon called hair sense so i tot it's da one ü cut ur hair.
 ham	Good morning pookie pie! Lol hope I didn't wake u up
 ham	MAYBE IF YOU WOKE UP BEFORE FUCKING 3 THIS WOULDN'T BE A PROBLEM.
 ham	Happy birthday to you....dear.with lots of love.rakhesh NRI
@@ -3193,7 +3193,7 @@ ham	Hi neva worry bout da truth coz the truth will lead me 2 ur heart. Its the
 spam	UR awarded a City Break and could WIN a £200 Summer Shopping spree every WK. Txt STORE to 88039.SkilGme.TsCs087147403231Winawk!Age16+£1.50perWKsub
 ham	Is ur paper today in e morn or aft?
 ham	I will lick up every drop :) are you ready to use your mouth as well?
-ham	And you! Will expect you whenever you text! Hope all goes well tomo 
+ham	And you! Will expect you whenever you text! Hope all goes well tomo
 ham	Great. P diddy is my neighbor and comes for toothpaste every morning
 ham	I av a new number,  . Wil u only use this one,ta.
 ham	So its to be poking man everyday that they teach you in canada abi! How are you. Just saying hi.
@@ -3224,7 +3224,7 @@ spam	Thanks for your ringtone order, reference number X29. Your mobile will be c
 ham	Hi, my love! How goes that day? Fuck, this morning I woke and dropped my cell on the way down the stairs but it seems alright ... *phews* I miss you !
 ham	Well that must be a pain to catch
 ham	Sorry da thangam.it's my mistake.
-ham	I need... Coz i never go before 
+ham	I need... Coz i never go before
 ham	Rose for red,red for blood,blood for heart,heart for u. But u for me.... Send tis to all ur friends.. Including me.. If u like me.. If u get back, 1-u r poor in relation! 2-u need some 1 to support 3-u r frnd 2 many 4-some1 luvs u 5+- some1 is praying god to marry u.:-) try it....
 ham	Wife.how she knew the time of murder exactly
 spam	SIX chances to win CASH! From 100 to 20,000 pounds txt> CSH11 and send to 87575. Cost 150p/day, 6days, 16+ TsandCs apply Reply HL 4 info
@@ -3280,14 +3280,14 @@ ham	Its a great day. Do have yourself a beautiful one.
 ham	What happened in interview?
 ham	Solve d Case : A Man Was Found Murdered On  &lt;DECIMAL&gt; . &lt;#&gt;  AfterNoon. 1,His wife called Police. 2,Police questioned everyone. 3,Wife: Sir,I was sleeping, when the murder took place. 4.Cook: I was cooking. 5.Gardener: I was picking vegetables. 6.House-Maid: I went 2 d post office. 7.Children: We went 2 play. 8.Neighbour: We went 2 a marriage. Police arrested d murderer Immediately. Who's It? Reply With Reason, If U r Brilliant.
 ham	Badrith is only for chennai:)i will surely pick for us:)no competition for him.
-ham	I tot it's my group mate... Lucky i havent reply... Wat time do ü need to leave... 
+ham	I tot it's my group mate... Lucky i havent reply... Wat time do ü need to leave...
 ham	Hey you around? I've got enough for a half + the ten I owe you
 ham	Hey tmr maybe can meet you at yck
 ham	ALRITE SAM ITS NIC JUST CHECKIN THAT THIS IS UR NUMBER-SO IS IT?T.B*
 ham	They are just making it easy to pay back. I have  &lt;#&gt; yrs to say but i can pay back earlier. You get?
 ham	Not to worry. I'm sure you'll get it.
 ham	The gas station is like a block away from my house, you'll drive right by it since armenia ends at swann and you have to take howard
-spam	Someone U know has asked our dating service 2 contact you! Cant Guess who? CALL 09058097189 NOW all will be revealed. POBox 6, LS15HB 150p 
+spam	Someone U know has asked our dating service 2 contact you! Cant Guess who? CALL 09058097189 NOW all will be revealed. POBox 6, LS15HB 150p
 spam	Camera - You are awarded a SiPix Digital Camera! call 09061221066 fromm landline. Delivery within 28 days
 ham	My tuition is at 330. Hm we go for the 1120 to 1205 one? Do you mind?
 ham	I'm not smoking while people use "wylie smokes too much" to justify ruining my shit
@@ -3296,7 +3296,7 @@ ham	A little. Meds say take once every 8 hours. It's only been 5 but pain is bac
 ham	Beautiful tomorrow never comes.. When it comes, it's already TODAY.. In the hunt of beautiful tomorrow don't waste your wonderful TODAY.. GOODMORNING:)
 ham	Dunno lei ü all decide lor. How abt leona? Oops i tot ben is going n i msg him.
 ham	Hi there. We have now moved in2 our pub . Would be great 2 c u if u cud come up.
-spam	Todays Voda numbers ending 5226 are selected to receive a ?350 award. If you hava a match please call 08712300220 quoting claim code 1131 standard rates app 
+spam	Todays Voda numbers ending 5226 are selected to receive a ?350 award. If you hava a match please call 08712300220 quoting claim code 1131 standard rates app
 spam	This message is free. Welcome to the new & improved Sex & Dogging club! To unsubscribe from this service reply STOP. msgs@150p 18 only
 ham	Honeybee Said: *I'm d Sweetest in d World* God Laughed &amp; Said: *Wait,U Havnt Met d Person Reading This Msg* MORAL: Even GOD Can Crack Jokes! GM+GN+GE+GN:)
 ham	Just do what ever is easier for you
@@ -3316,9 +3316,9 @@ ham	Huh... Hyde park not in mel ah, opps, got confused... Anyway, if tt's e best
 ham	Oh gei. That happend to me in tron. Maybe ill dl it in 3d when its out
 spam	FREE MESSAGE Activate your 500 FREE Text Messages by replying to this message with the word FREE For terms & conditions, visit www.07781482378.com
 ham	I know girls always safe and selfish know i got it pa. Thank you. good night.
-ham	No worries, hope photo shoot went well. have a spiffing fun at workage. 
+ham	No worries, hope photo shoot went well. have a spiffing fun at workage.
 ham	I'm freezing and craving ice. Fml
-ham	Kay... Since we are out already 
+ham	Kay... Since we are out already
 ham	Eh sorry leh... I din c ur msg. Not sad already lar. Me watching tv now. U still in office?
 ham	Yo im right by yo work
 ham	Ok darlin i supose it was ok i just worry too much.i have to do some film stuff my mate and then have to babysit again! But you can call me there.xx
@@ -3355,7 +3355,7 @@ ham	Call him and say you not coming today ok and tell them not to fool me like t
 ham	I emailed yifeng my part oredi.. Can ü get it fr him..
 ham	R u sure they'll understand that! Wine * good idea just had a slurp!
 ham	Minimum walk is 3miles a day.
-ham	Ok not a problem will get them a taxi. C ing  tomorrow and tuesday. On tuesday think we r all going to the cinema. 
+ham	Ok not a problem will get them a taxi. C ing  tomorrow and tuesday. On tuesday think we r all going to the cinema.
 ham	Brainless Baby Doll..:-D;-), vehicle sariyag drive madoke barolla..
 ham	I don't run away frm u... I walk slowly &amp; it kills me that u don't care enough to stop me...
 spam	Sorry I missed your call let's talk when you have the time. I'm on 07090201529
@@ -3374,7 +3374,7 @@ ham	Tomorrow i am not going to theatre. . . So i can come wherever u call me. . 
 ham	And now electricity just went out fml.
 ham	Looks like you found something to do other than smoke, great job!
 ham	Also andros ice etc etc
-ham	:) 
+ham	:)
 ham	Good afternon, my love. How are today? I hope your good and maybe have some interviews. I wake and miss you babe. A passionate kiss from across the sea
 ham	Yup. Wun believe wat? U really neva c e msg i sent shuhui?
 ham	Hows that watch resizing
@@ -3408,7 +3408,7 @@ ham	Jus chillaxin, what up
 ham	"HEY DAS COOL... IKNOW ALL 2 WELLDA PERIL OF STUDENTFINANCIAL CRISIS!SPK 2 U L8R."
 ham	Beautiful Truth against Gravity.. Read carefully: "Our heart feels light when someone is in it.. But it feels very heavy when someone leaves it.." GOODMORNING
 spam	Do you want a New Nokia 3510i colour phone DeliveredTomorrow? With 300 free minutes to any mobile + 100 free texts + Free Camcorder reply or call 08000930705
-ham	Whats that coming over the hill..... Is it a monster! Hope you have a great day. Things r going fine here, busy though! 
+ham	Whats that coming over the hill..... Is it a monster! Hope you have a great day. Things r going fine here, busy though!
 ham	Joy's father is John. Then John is the ____ of Joy's father. If u ans ths you hav  &lt;#&gt;  IQ. Tis s IAS question try to answer.
 ham	Only once then after ill obey all yours.
 ham	No she didnt. I will search online and let you know.
@@ -3426,7 +3426,7 @@ spam	Had your mobile 10 mths? Update to latest Orange camera/video phones for FR
 spam	Am new 2 club & dont fink we met yet Will B gr8 2 C U Please leave msg 2day wiv ur area 09099726553 reply promised CARLIE x Calls£1/minMobsmore LKPOBOX177HP51FL
 ham	True. Its easier with her here.
 ham	Sure but since my parents will be working on Tuesday I don't really need a cover story
-ham	Haha okay... Today weekend leh... 
+ham	Haha okay... Today weekend leh...
 ham	"Hi darlin did youPhone me? Im atHome if youwanna chat."
 ham	I don't know jack shit about anything or i'd say/ask something helpful but if you want you can pretend that I did and just text me whatever in response to the hypotheticalhuagauahahuagahyuhagga
 ham	You've always been the brainy one.
@@ -3445,10 +3445,10 @@ spam	Save money on wedding lingerie at www.bridal.petticoatdreams.co.uk Choose f
 ham	Your board is working fine. The issue of overheating is also reslove. But still software inst is pending. I will come around 8'o clock.
 ham	Yes but I don't care cause I know its there!
 ham	wiskey Brandy Rum Gin Beer Vodka Scotch Shampain Wine "KUDI"yarasu dhina vaazhthukkal. ..
-ham	Mon okie lor... Haha, best is cheap n gd food la, ex oso okie... Depends on whether wana eat western or chinese food... Den which u prefer... 
+ham	Mon okie lor... Haha, best is cheap n gd food la, ex oso okie... Depends on whether wana eat western or chinese food... Den which u prefer...
 ham	Sitting ard nothing to do lor. U leh busy w work?
 ham	Its  &lt;#&gt; k here oh. Should i send home for sale.
-ham	Sorry. || mail? || 
+ham	Sorry. || mail? ||
 ham	Ya just telling abt tht incident..
 ham	Yes we were outside for like 2 hours. And I called my whole family to wake them up cause it started at 1 am
 ham	Ugh just got outta class
@@ -3489,7 +3489,7 @@ ham	Yeah, probably earlier than that
 ham	Change windows logoff sound..
 ham	Still i have not checked it da. . .
 ham	I'm also came to room.
-ham	Huh but i got lesson at 4 lei n i was thinkin of going to sch earlier n i tot of parkin at kent vale...  
+ham	Huh but i got lesson at 4 lei n i was thinkin of going to sch earlier n i tot of parkin at kent vale...
 ham	Ok.
 ham	I will reach office around  &lt;DECIMAL&gt; . &amp; my mobile have problem. You cann't get my voice. So call you asa i'll free
 ham	Cool, text me when you head out
@@ -3507,7 +3507,7 @@ ham	Will you be here for food
 ham	life alle mone,eppolum oru pole allalo
 ham	Nite...
 ham	Two fundamentals of cool life: "Walk, like you are the KING"...! OR "Walk like you Dont care,whoever is the KING"!... Gud nyt
-ham	Camera quite good, 10.1mega pixels, 3optical and 5digital dooms. Have a lovely holiday, be safe and i hope you hav a good journey! Happy new year to you both! See you in a couple of weeks! 
+ham	Camera quite good, 10.1mega pixels, 3optical and 5digital dooms. Have a lovely holiday, be safe and i hope you hav a good journey! Happy new year to you both! See you in a couple of weeks!
 ham	Hi Petey!noim ok just wanted 2 chat coz avent spoken 2 u 4 a long time-hope ur doin alrite.have good nit at js love ya am.x
 ham	I just saw ron burgundy captaining a party boat so yeah
 ham	I'm serious. You are in the money base
@@ -3520,7 +3520,7 @@ ham	So you think i should actually talk to him? Not call his boss in the morning
 ham	Are you willing to go for apps class.
 ham	Hanging out with my brother and his family
 ham	No it will reach by 9 only. She telling she will be there. I dont know
-ham	Hey... are you going to quit soon? Xuhui and i working till end of the month 
+ham	Hey... are you going to quit soon? Xuhui and i working till end of the month
 ham	Im sorry bout last nite it wasnt ur fault it was me, spouse it was pmt or sumthin! U 4give me? I think u shldxxxx
 ham	Try neva mate!!
 ham	Yeah that'd pretty much be the best case scenario
@@ -3577,7 +3577,7 @@ ham	Yeah sure I'll leave in a min
 ham	And do you have any one that can teach me how to ship cars.
 ham	The sign of maturity is not when we start saying big things.. But actually it is, when we start understanding small things... *HAVE A NICE EVENING* BSLVYL
 ham	Yeah confirmed for you staying at  that weekend
-ham	They said ü dun haf passport or smth like dat.. Or ü juz send to my email account..  
+ham	They said ü dun haf passport or smth like dat.. Or ü juz send to my email account..
 ham	Multiply the numbers independently and count decimal points then, for the division, push the decimal places like i showed you.
 ham	Have a lovely night and when you wake up to see this message, i hope you smile knowing all is as should be. Have a great morning
 ham	Ard 4 lor...
@@ -3618,10 +3618,10 @@ ham	I enjoy watching and playing football and basketball. Anything outdoors. And
 ham	Can you please ask macho what his price range is, does he want something new or used plus it he only interfued in the blackberry bold  &lt;#&gt;  or any bb
 ham	Sorry sent blank msg again. Yup but trying 2 do some serious studying now.
 ham	Hey check it da. I have listed da.
-spam	8007 25p 4 Alfie Moon's Children in Need song on ur mob. Tell ur m8s. Txt TONE CHARITY to 8007 for nokias or POLY CHARITY for polys :zed 08701417012 profit 2 charity 
+spam	8007 25p 4 Alfie Moon's Children in Need song on ur mob. Tell ur m8s. Txt TONE CHARITY to 8007 for nokias or POLY CHARITY for polys :zed 08701417012 profit 2 charity
 ham	I meant as an apology from me for texting you to get me drugs at  &lt;#&gt; at night
 ham	That means from february to april i'll be getting a place to stay down there so i don't have to hustle back and forth during audition season as i have since my sister moved away from harlem.
-ham	Goin to workout lor... Muz lose e fats... 
+ham	Goin to workout lor... Muz lose e fats...
 ham	Damn, poor zac doesn't stand a chance
 ham	No message..no responce..what happend?
 ham	I want to tel u one thing u should not mistake me k THIS IS THE MESSAGE THAT YOU SENT:)
@@ -3661,7 +3661,7 @@ ham	R u here yet? I'm wearing blue shirt n black pants.
 ham	Wait.i will come out.. &lt;#&gt;  min:)
 ham	I will reach ur home in  &lt;#&gt;  minutes
 ham	Well then you have a great weekend!
-ham	What are you doing in langport? Sorry, but I'll probably be in bed by 9pm. It sucks being ill at xmas! When do you and go2sri lanka? 
+ham	What are you doing in langport? Sorry, but I'll probably be in bed by 9pm. It sucks being ill at xmas! When do you and go2sri lanka?
 ham	Frnd s not juz a word.....not merely a relationship.....its a silent promise which says ... " I will be with YOU " Wherevr.. Whenevr.. Forevr... Gudnyt dear..
 ham	Huh? 6 also cannot? Then only how many mistakes?
 ham	Ha... U jus ate honey ar? So sweet...
@@ -3746,7 +3746,7 @@ ham	Nah, Wednesday. When should I bring the mini cheetos bag over?
 ham	Nobody names their penis a girls name this story doesn't add up at all
 ham	Aight, let me know when you're gonna be around usf
 ham	I'm not. She lip synced with shangela.
-ham	Ü neva tell me how i noe... I'm not at home in da aft wat... 
+ham	Ü neva tell me how i noe... I'm not at home in da aft wat...
 ham	A bit of Ur smile is my hppnss, a drop of Ur tear is my sorrow, a part of Ur heart is my life, a heart like mine wil care for U, forevr as my GOODFRIEND
 spam	Dear Voucher Holder 2 claim your 1st class airport lounge passes when using Your holiday voucher call 08704439680. When booking quote 1st class x 2
 ham	Buzz! Hey, my Love ! I think of you and hope your day goes well. Did you sleep in ? I miss you babe. I long for the moment we are together again*loving smile*
@@ -3764,7 +3764,7 @@ ham	Was just about to ask. Will keep this one. Maybe that's why you didn't get a
 spam	FREE for 1st week! No1 Nokia tone 4 ur mob every week just txt NOKIA to 8007 Get txting and tell ur mates www.getzed.co.uk POBox 36504 W45WQ norm150p/tone 16+
 ham	K.i will send in  &lt;#&gt;  min:)
 ham	Would me smoking you out help us work through this difficult time
-spam	Someone U know has asked our dating service 2 contact you! Cant guess who? CALL 09058095107 NOW all will be revealed. POBox 7, S3XY 150p 
+spam	Someone U know has asked our dating service 2 contact you! Cant guess who? CALL 09058095107 NOW all will be revealed. POBox 7, S3XY 150p
 ham	Yes.mum lookin strong:)
 ham	Sir Goodmorning, Once free call me.
 ham	Where are you call me.
@@ -3826,7 +3826,7 @@ ham	Please protect yourself from e-threats. SIB never asks for sensitive informa
 ham	I miss you so much I'm so desparate I have recorded the message you left for me the other day and listen to it just to hear the sound of your voice. I love you
 ham	Hi. I'm always online on yahoo and would like to chat with you someday
 ham	Goodmorning,my grandfather expired..so am on leave today.
-spam	Congratulations U can claim 2 VIP row A Tickets 2 C Blu in concert in November or Blu gift guaranteed Call 09061104276 to claim TS&Cs www.smsco.net cost£3.75max 
+spam	Congratulations U can claim 2 VIP row A Tickets 2 C Blu in concert in November or Blu gift guaranteed Call 09061104276 to claim TS&Cs www.smsco.net cost£3.75max
 ham	Where are you ? What are you doing ? Are yuou working on getting the pc to your mom's ? Did you find a spot that it would work ? I need you
 ham	Sure, I'll see if I can come by in a bit
 ham	I agree. So i can stop thinkin about ipad. Can you please ask macho the same question.
@@ -3849,7 +3849,7 @@ ham	Pls go there today  &lt;#&gt; . I dont want any excuses
 spam	Fantasy Football is back on your TV. Go to Sky Gamestar on Sky Active and play £250k Dream Team. Scoring starts on Saturday, so register now!SKY OPT OUT to 88088
 ham	Can you plz tell me the ans. BSLVYL sent via fullonsms.com
 ham	U in town alone?
-ham	I to am looking forward to all the sex cuddling.. Only two more sleeps 
+ham	I to am looking forward to all the sex cuddling.. Only two more sleeps
 ham	We have all rounder:)so not required:)
 ham	No, its true..k,Do u knw dis no. &lt;#&gt; ?
 ham	Dont worry, 1 day very big lambu ji vl come..til then enjoy batchlor party:-)
@@ -3898,7 +3898,7 @@ ham	Yes. Last  practice
 spam	tells u 2 call 09066358152 to claim £5000 prize. U have 2 enter all ur mobile & personal details @ the prompts. Careful!
 ham	No. Thank you. You've been wonderful
 ham	Otherwise had part time job na-tuition..
-ham	Ü mean it's confirmed... I tot they juz say oni... Ok then... 
+ham	Ü mean it's confirmed... I tot they juz say oni... Ok then...
 ham	Okie
 ham	That depends. How would you like to be treated? :)
 ham	Right on brah, see you later
@@ -3925,11 +3925,11 @@ ham	Oh really? perform, write a paper, go to a movie AND be home by midnight, hu
 ham	Okay lor... Will they still let us go a not ah? Coz they will not know until later. We drop our cards into the box right?
 ham	How? Izzit still raining?
 ham	As if i wasn't having enough trouble sleeping.
-ham	I havent add ü yet right.. 
+ham	I havent add ü yet right..
 ham	Lol ... I really need to remember to eat when I'm drinking but I do appreciate you keeping me company that night babe *smiles*
 ham	Babe ? I lost you ... Will you try rebooting ?
 ham	Yes. Nigh you cant aha.
-ham	I thk ü gotta go home by urself. Cos i'll b going out shopping 4 my frens present. 
+ham	I thk ü gotta go home by urself. Cos i'll b going out shopping 4 my frens present.
 ham	Nooooooo I'm gonna be bored to death all day. Cable and internet outage.
 ham	Sos! Any amount i can get pls.
 ham	Playin space poker, u?
@@ -3951,11 +3951,11 @@ ham	I like to think there's always the possibility of being in a pub later.
 ham	HMM yeah if your not too grooved out! And im looking forward to my pound special :)
 ham	I got to video tape pple type in message lor. U so free wan 2 help me? Hee... Cos i noe u wan 2 watch infernal affairs so ask u along. Asking shuhui oso.
 ham	Hi dude hw r u da realy mising u today
-ham	Me hungry buy some food good lei... But mum n yun dun wan juz buy a little bit... 
+ham	Me hungry buy some food good lei... But mum n yun dun wan juz buy a little bit...
 spam	Refused a loan? Secured or Unsecured? Can't get credit? Call free now 0800 195 6669 or text back 'help' & we will!
 ham	I probably won't eat at all today. I think I'm gonna pop. How was your weekend? Did u miss me?
 ham	I knew it... U slept v late yest? Wake up so late...
-ham	Haha... dont be angry with yourself... Take it as a practice for the real thing. =) 
+ham	Haha... dont be angry with yourself... Take it as a practice for the real thing. =)
 ham	Where is that one day training:-)
 ham	So i could kiss and feel you next to me...
 ham	Have a nice day my dear.
@@ -3969,7 +3969,7 @@ ham	I was just callin to say hi. Take care bruv!
 spam	YOU HAVE WON! As a valued Vodafone customer our computer has picked YOU to win a £150 prize. To collect is easy. Just call 09061743386
 ham	Did u turn on the heater? The heater was on and set to &lt;#&gt; degrees.
 ham	Thanks for your message. I really appreciate your sacrifice. I'm not sure of the process of direct pay but will find out on my way back from the test tomorrow. I'm in class now. Do have a wonderful day.
-ham	That's the trouble with classes that go well - you're due a dodgey one … Expecting mine tomo! See you for recovery, same time, same place 
+ham	That's the trouble with classes that go well - you're due a dodgey one … Expecting mine tomo! See you for recovery, same time, same place
 spam	Free video camera phones with Half Price line rental for 12 mths and 500 cross ntwk mins 100 txts. Call MobileUpd8 08001950382 or Call2OptOut/674&
 ham	WOT U UP 2 J?
 ham	Night night, see you tomorrow
@@ -4004,11 +4004,11 @@ ham	He's just gonna worry for nothing. And he won't give you money its no use.
 ham	Did you get any gift? This year i didnt get anything. So bad
 ham	somewhere out there beneath the pale moon light someone think in of u some where out there where dreams come true... goodnite &amp; sweet dreams
 ham	Well there's a pattern emerging of my friends telling me to drive up and come smoke with them and then telling me that I'm a weed fiend/make them smoke too much/impede their doing other things so you see how I'm hesitant
-ham	, ow u dey.i paid 60,400thousad.i told  u would call . 
+ham	, ow u dey.i paid 60,400thousad.i told  u would call .
 ham	IM FINE BABES AINT BEEN UP 2 MUCH THO! SAW SCARY MOVIE YEST ITS QUITE FUNNY! WANT 2MRW AFTERNOON? AT TOWN OR MALL OR SUMTHIN?xx
 ham	I'm reaching home in 5 min.
 ham	Forgot you were working today! Wanna chat, but things are ok so drop me a text when you're free / bored etc and i'll ring. Hope all is well, nose essay and all xx
-ham	Ha... Then we must walk to everywhere... Cannot take tram. My cousin said can walk to vic market from our hotel 
+ham	Ha... Then we must walk to everywhere... Cannot take tram. My cousin said can walk to vic market from our hotel
 spam	Wan2 win a Meet+Greet with Westlife 4 U or a m8? They are currently on what tour? 1)Unbreakable, 2)Untamed, 3)Unkempt. Text 1,2 or 3 to 83049. Cost 50p +std text
 spam	Please call our customer service representative on FREEPHONE 0808 145 4742 between 9am-11pm as you have WON a guaranteed £1000 cash or £5000 prize!
 ham	Discussed with your mother ah?
@@ -4036,7 +4036,7 @@ ham	I am taking you for italian food. How about a pretty dress with no panties? 
 ham	Wot u up 2? Thout u were gonna call me!! Txt bak luv K
 spam	YOU ARE CHOSEN TO RECEIVE A £350 AWARD! Pls call claim number 09066364311 to collect your award which you are selected to receive as a valued mobile customer.
 ham	How are you holding up?
-ham	Dont flatter yourself... Tell that man of mine two pints of carlin in ten minutes please.... 
+ham	Dont flatter yourself... Tell that man of mine two pints of carlin in ten minutes please....
 ham	Hope you are not scared!
 ham	I cant pick the phone right now. Pls send a message
 ham	I'm at home n ready...
@@ -4066,7 +4066,7 @@ ham	How are you. Its been ages. How's abj
 ham	Prof: you have passed in all the papers in this sem congrats . . . . Student: Enna kalaachutaarama..!! Prof:???? Gud mrng!
 ham	Dont kick coco when he's down
 ham	Fyi I'm gonna call you sporadically starting at like  &lt;#&gt;  bc we are not not doin this shit
-spam	You are being contacted by our Dating Service by someone you know! To find out who it is, call from your mobile or landline 09064017305 PoBox75LDNS7 
+spam	You are being contacted by our Dating Service by someone you know! To find out who it is, call from your mobile or landline 09064017305 PoBox75LDNS7
 spam	TBS/PERSOLVO. been chasing us since Sept for£38 definitely not paying now thanks to your information. We will ignore them. Kath. Manchester.
 ham	Hope youre not having too much fun without me!! see u tomorrow love jess x
 ham	Ok i wont call or disturb any one. I know all are avoiding me. I am a burden for all
@@ -4262,12 +4262,12 @@ ham	Sad story of a Man - Last week was my b'day. My Wife did'nt wish me. My Pare
 ham	Are you plans with your family set in stone ?
 ham	Pls dont forget to study
 ham	You'll never believe this but i have actually got off at taunton. Wow
-ham	Den only weekdays got special price... Haiz... Cant eat liao... Cut nails oso muz wait until i finish drivin wat, lunch still muz eat wat... 
+ham	Den only weekdays got special price... Haiz... Cant eat liao... Cut nails oso muz wait until i finish drivin wat, lunch still muz eat wat...
 ham	She just broke down a list of reasons why nobody's in town and I can't tell if she's being sarcastic or just faggy
 ham	 &lt;DECIMAL&gt; m but its not a common car here so its better to buy from china or asia. Or if i find it less expensive. I.ll holla
 ham	The greatest test of courage on earth is to bear defeat without losing heart....gn tc
 ham	SORRY IM STIL FUCKED AFTER LAST NITE WENT TOBED AT 430 GOT UP 4 WORK AT 630
-ham	Hey so whats the plan this sat? 
+ham	Hey so whats the plan this sat?
 ham	Beauty sleep can help ur pimples too.
 ham	Great. Hope you are using your connections from mode men also cos you can never know why old friends can lead you to today
 spam	Natalja (25/F) is inviting you to be her friend. Reply YES-440 or NO-440 See her: www.SMS.ac/u/nat27081980 STOP? Send STOP FRND to 62468
@@ -4287,7 +4287,7 @@ ham	Yes. I come to nyc for audiitions and am trying to relocate.
 ham	I pocked you up there before
 ham	Congrats. That's great. I wanted to tell you not to tell me your score cos it might make me relax. But its motivating me so thanks for sharing
 ham	I wud never mind if u dont miss me or if u dont need me.. But u wil really hurt me wen u need me &amp; u dont tell me......... Take care:-)
-ham	Hey mr whats the name of that bill brison book the one about language and words 
+ham	Hey mr whats the name of that bill brison book the one about language and words
 ham	Okay, good, no problem, and thanx!
 ham	For you information, IKEA is spelled with all caps. That is not yelling. when you thought i had left you, you were sitting on the bed among the mess when i came in. i said we were going after you got home from class. please don't try and bullshit me. It makes me want to listen to you less.
 ham	Call me when u're done...
@@ -4316,10 +4316,10 @@ ham	I wasn't well babe, i have swollen glands at my throat ... What did you end 
 ham	Is ur changes 2 da report big? Cos i've already made changes 2 da previous report.
 ham	Captain is in our room:)
 ham	I can't speak, bcaz mobile have problem. I can listen you but you cann't listen my voice. So i calls you later.
-ham	HIYA STU WOT U UP 2.IM IN SO MUCH TRUBLE AT HOME AT MOMENT EVONE HATES ME EVEN U! WOT THE HELL AV I DONE NOW? Y WONT U JUST TELL ME TEXT BCK PLEASE LUV DAN 
+ham	HIYA STU WOT U UP 2.IM IN SO MUCH TRUBLE AT HOME AT MOMENT EVONE HATES ME EVEN U! WOT THE HELL AV I DONE NOW? Y WONT U JUST TELL ME TEXT BCK PLEASE LUV DAN
 ham	S...i will take mokka players only:)
 ham	Are you still playing with gautham?
-ham	Hey mr  and I are going to the sea view and having a couple of gays I mean games! Give me a bell when ya finish 
+ham	Hey mr  and I are going to the sea view and having a couple of gays I mean games! Give me a bell when ya finish
 ham	K, jason says he's gonna be around so I'll be up there around  &lt;#&gt;
 ham	Sorry . I will be able to get to you. See you in the morning.
 ham	Aight well keep me informed
@@ -4332,7 +4332,7 @@ ham	1Apple/Day=No Doctor. 1Tulsi Leaf/Day=No Cancer. 1Lemon/Day=No Fat. 1Cup Mil
 ham	i thought we were doing a king of the hill thing there.
 ham	Nope i'll come online now..
 ham	ALSO TELL HIM I SAID HAPPY BIRTHDAY
-ham	Y bishan lei... I tot ü say lavender? 
+ham	Y bishan lei... I tot ü say lavender?
 ham	Boo what time u get out? U were supposed to take me shopping today. :(
 ham	Now u sound like manky scouse boy steve,like! I is travelling on da bus home.wot has u inmind 4 recreation dis eve?
 ham	Fyi I'm taking a quick shower, be at epsilon in like  &lt;#&gt;  min
@@ -4359,7 +4359,7 @@ ham	Great. So should i send you my account number.
 ham	HELLOGORGEOUS, HOWS U? MY FONE WAS ON CHARGE LST NITW WEN U TEXD ME. HOPEU AD A NICE WKEND AS IM SURE U DID LOOKIN 4WARD 2 C-IN U 2MRW LUV JAZ
 spam	Our dating service has been asked 2 contact U by someone shy! CALL 09058091870 NOW all will be revealed. POBox84, M26 3UZ 150p
 ham	Ü only send me the contents page...
-ham	Night sweet, sleep well! I've just been to see The Exorcism of Emily Rose and may never sleep again! Hugs and snogs! 
+ham	Night sweet, sleep well! I've just been to see The Exorcism of Emily Rose and may never sleep again! Hugs and snogs!
 ham	Don't Think About "What u Have Got" Think About "How to Use It That You Have Got" gooD ni8
 ham	I can't right this second, gotta hit people up first
 ham	Evry Emotion dsn't hav Words.Evry Wish dsn't hav Prayrs.. If u Smile,D World is wit u.Othrwise even d Drop of Tear dsn't lik 2 Stay wit u.So b happy.. Good morning, keep smiling:-)
@@ -4385,7 +4385,7 @@ ham	yeah sure thing mate haunt got all my stuff sorted but im going sound anyway
 ham	No need lar i go engin? Cos my sis at arts today...
 ham	Thanks honey but still haven't heard anything I will leave it a bit longer so not 2 crowd him and will try later - great advice thanks hope cardiff is still there!
 spam	Do you want a New Nokia 3510i Colour Phone Delivered Tomorrow? With 200 FREE minutes to any mobile + 100 FREE text + FREE camcorder Reply or Call 8000930705
-ham	, im .. On the snowboarding trip. I was wondering if your planning to get everyone together befor we go..a meet and greet kind of affair? Cheers, 
+ham	, im .. On the snowboarding trip. I was wondering if your planning to get everyone together befor we go..a meet and greet kind of affair? Cheers,
 ham	S.i'm watching it in live..
 ham	see you then, we're all christmassy here!
 ham	K I'm ready,  &lt;#&gt; ?
@@ -4400,7 +4400,7 @@ ham	When did dad get back.
 ham	Can you tell Shola to please go to college of medicine and visit the academic department, tell the academic secretary what the current situation is and ask if she can transfer there. She should ask someone to check Sagamu for the same thing and lautech. Its vital she completes her medical education in Nigeria. Its less expensive much less expensive. Unless she will be getting citizen rates in new zealand.
 ham	Yes just finished watching days of our lives. I love it.
 ham	Juz go google n search 4 qet...
-ham	Many times we lose our best ones bcoz we are 
+ham	Many times we lose our best ones bcoz we are
 ham	Good FRIENDS CaRE for each Other.. CLoSE Friends UNDERSTaND each Other... and TRUE Friends STaY forever beyond words, beyond time. Gud ni8
 ham	Just getting back home
 ham	Sorry, I'll call later  &lt;#&gt; mins
@@ -4546,13 +4546,13 @@ ham	I've been trying to reach him without success
 ham	when you and derek done with class?
 ham	Never y lei... I v lazy... Got wat? Dat day ü send me da url cant work one...
 ham	Never try alone to take the weight of a tear that comes out of ur heart and falls through ur eyes... Always remember a STUPID FRIEND is here to share... BSLVYL
-ham	Hey mate. Spoke to the mag people. We‘re on.  the is deliver by the end of the month. Deliver on the 24th sept. Talk later. 
+ham	Hey mate. Spoke to the mag people. We‘re on.  the is deliver by the end of the month. Deliver on the 24th sept. Talk later.
 ham	Hope you are having a good week. Just checking in
 ham	Haha, my friend tyler literally just asked if you could get him a dubsack
 ham	"Hey! do u fancy meetin me at 4 at cha  hav a lil beverage on me. if not txt or ring me and we can meet up l8r. quite tired got in at 3 v.pist ;) love Pete x x x"
 ham	Great. Have a safe trip. Dont panic surrender all.
 ham	"SYMPTOMS" when U are in love: "1.U like listening songs 2.U get stopped where u see the name of your beloved 3.U won't get angry when your
-ham	Sun ah... Thk mayb can if dun have anythin on... Thk have to book e lesson... E pilates is at orchard mrt u noe hor...  
+ham	Sun ah... Thk mayb can if dun have anythin on... Thk have to book e lesson... E pilates is at orchard mrt u noe hor...
 ham	Try to do something dear. You read something for exams
 ham	7 wonders in My WORLD 7th You 6th Ur style 5th Ur smile 4th Ur Personality 3rd Ur Nature 2nd Ur SMS and 1st "Ur Lovely Friendship"... good morning dear
 ham	Gettin rdy to ship comp
@@ -4597,15 +4597,15 @@ ham	I had a good time too. Its nice to do something a bit different with my week
 ham	Yo sorry was in the shower sup
 ham	Carlos is down but I have to pick it up from him, so I'll swing by usf in a little bit
 ham	Full heat pa:-) i have applyed oil pa.
-ham	I'm stuck in da middle of da row on da right hand side of da lt... 
+ham	I'm stuck in da middle of da row on da right hand side of da lt...
 ham	Have you laid your airtel line to rest?
-ham	Hi did u decide wot 2 get 4 his bday if not ill prob jus get him a voucher frm virgin or sumfing 
+ham	Hi did u decide wot 2 get 4 his bday if not ill prob jus get him a voucher frm virgin or sumfing
 spam	FreeMsg: Txt: CALL to No: 86888 & claim your reward of 3 hours talk time to use from your phone now! Subscribe6GBP/mnth inc 3hrs 16 stop?txtStop
 ham	"Hey j! r u feeling any better, hopeSo hunny. i amnow feelin ill & ithink i may have tonsolitusaswell! damn iam layin in bedreal bored. lotsof luv me xxxx"
 ham	And I don't plan on staying the night but I prolly won't be back til late
 ham	THANX 4 PUTTIN DA FONE DOWN ON ME!!
 ham	I need an 8th but I'm off campus atm, could I pick up in an hour or two?
-ham	Oh... Haha... Den we shld had went today too... Gee, nvm la... Kaiez, i dun mind goin jazz oso... Scared hiphop open cant catch up... 
+ham	Oh... Haha... Den we shld had went today too... Gee, nvm la... Kaiez, i dun mind goin jazz oso... Scared hiphop open cant catch up...
 ham	Been running but only managed 5 minutes and then needed oxygen! Might have to resort to the roller option!
 ham	We live in the next  &lt;#&gt; mins
 ham	Y de asking like this.
@@ -4650,7 +4650,7 @@ ham	God created gap btwn ur fingers so dat sum1 vry special will fill those gaps
 ham	We are okay. Going to sleep now. Later
 ham	Please protect yourself from e-threats. SIB never asks for sensitive information like Passwords,ATM/SMS PIN thru email. Never share your password with anybody.
 ham	Finally it has happened..! Aftr decades..! BEER is now cheaper than PETROL! The goverment expects us to "DRINK". . . But don't "DRIVE "
-spam	A £400 XMAS REWARD IS WAITING FOR YOU! Our computer has randomly picked you from our loyal mobile customers to receive a £400 reward. Just call 09066380611 
+spam	A £400 XMAS REWARD IS WAITING FOR YOU! Our computer has randomly picked you from our loyal mobile customers to receive a £400 reward. Just call 09066380611
 ham	Where r e meeting tmr?
 ham	Lol yes. But it will add some spice to your day.
 ham	Hope you are having a great day.
@@ -4667,7 +4667,7 @@ ham	Mum not going robinson already.
 ham	Ok set let u noe e details later...
 ham	Not..tel software name..
 ham	I send the print  outs da.
-ham	IM REALY SOZ IMAT MY MUMS 2NITE WHAT ABOUT 2MORO 
+ham	IM REALY SOZ IMAT MY MUMS 2NITE WHAT ABOUT 2MORO
 ham	When I was born, GOD said, "Oh No! Another IDIOT". When you were born, GOD said, "OH No! COMPETITION". Who knew, one day these two will become FREINDS FOREVER!
 ham	I didnt get ur full msg..sometext is missing, send it again
 ham	Probably not, I'm almost out of gas and I get some cash tomorrow
@@ -4698,7 +4698,7 @@ spam	URGENT! Your Mobile No 07808726822 was awarded a £2,000 Bonus Caller Prize
 ham	A guy who gets used but is too dumb to realize it.
 ham	Okey dokey, i‘ll be over in a bit just sorting some stuff out.
 ham	Don no da:)whats you plan?
-ham	Yes fine 
+ham	Yes fine
 spam	WIN: We have a winner! Mr. T. Foley won an iPod! More exciting prizes soon, so keep an eye on ur mobile or visit www.win-82050.co.uk
 ham	I liked the new mobile
 ham	Anytime...
@@ -4780,7 +4780,7 @@ ham	Sorry completely forgot * will pop em round this week if your still here?
 ham	U R THE MOST BEAUTIFUL GIRL IVE EVER SEEN. U R MY BABY COME AND C ME IN THE COMMON ROOM
 ham	O we cant see if we can join denis and mina? Or does denis want alone time
 ham	Sen told that he is going to join his uncle finance in cbe
-ham	Yup... Hey then one day on fri we can ask miwa and jiayin take leave go karaoke 
+ham	Yup... Hey then one day on fri we can ask miwa and jiayin take leave go karaoke
 ham	Call me, i am senthil from hsbc.
 ham	Especially since i talk about boston all up in my personal statement, lol! I woulda changed that if i had realized it said nyc! It says boston now.
 ham	Indeed and by the way it was either or - not both !
@@ -4814,7 +4814,7 @@ ham	E admin building there? I might b slightly earlier... I'll call u when i'm r
 ham	fyi I'm at usf now, swing by the room whenever
 ham	i can call in  &lt;#&gt;  min if thats ok
 ham	Ummmmmaah Many many happy returns of d day my dear sweet heart.. HAPPY BIRTHDAY dear
-ham	Ü no home work to do meh... 
+ham	Ü no home work to do meh...
 ham	Anything is valuable in only 2 situations: First- Before getting it... Second- After loosing it...
 ham	Me too. Mark is taking forever to pick up my prescription and the pain is coming back.
 ham	How's ur paper?
@@ -4843,7 +4843,7 @@ spam	PRIVATE! Your 2003 Account Statement for shows 800 un-redeemed S. I. M. poi
 ham	Hmmm.... Mayb can try e shoppin area one, but forgot e name of hotel...
 ham	Awesome, that gonna be soon or later tonight?
 ham	I need details about that online job.
-spam	YOU HAVE WON! As a valued Vodafone customer our computer has picked YOU to win a £150 prize. To collect is easy. Just call 09061743386 
+spam	YOU HAVE WON! As a valued Vodafone customer our computer has picked YOU to win a £150 prize. To collect is easy. Just call 09061743386
 ham	Missing you too.pray inshah allah
 ham	Pls help me tell Ashley that i cant find her number oh
 ham	I am in escape theatre now. . Going to watch KAVALAN in a few minutes
@@ -4856,7 +4856,7 @@ ham	I'm fine. Hope you are also
 ham	Also north carolina and texas atm, you would just go to the gre site and pay for the test results to be sent.
 ham	Same to u...
 ham	yes baby! I need to stretch open your pussy!
-ham	Thanks  and ! Or bomb and date as my phone wanted to say! 
+ham	Thanks  and ! Or bomb and date as my phone wanted to say!
 ham	Ok...
 ham	Hey, a guy I know is breathing down my neck to get him some bud, anyway you'd be able to get a half track to usf tonight?
 ham	"Response" is one of d powerful weapon 2 occupy a place in others 'HEART'... So, always give response 2 who cares 4 U"... Gud night..swt dreams..take care
@@ -4872,7 +4872,7 @@ ham	1. Tension face 2. Smiling face 3. Waste face 4. Innocent face 5.Terror face
 ham	Dip's cell dead. So i m coming with him. U better respond else we shall come back.
 ham	Well. You know what i mean. Texting
 ham	Hi dis is yijue i would be happy to work wif ü all for gek1510...
-ham	Lol! Oops sorry! Have fun. 
+ham	Lol! Oops sorry! Have fun.
 ham	Wat happened to the cruise thing
 ham	I know dat feelin had it with Pete! Wuld get with em , nuther place nuther time mayb?
 spam	lyricalladie(21/F) is inviting you to be her friend. Reply YES-910 or NO-910. See her: www.SMS.ac/u/hmmross STOP? Send STOP FRND to 62468
@@ -4914,7 +4914,7 @@ ham	Love that holiday Monday feeling even if I have to go to the dentists in an 
 ham	I am on the way to tirupur.
 spam	Goal! Arsenal 4 (Henry, 7 v Liverpool 2 Henry scores with a simple shot from 6 yards from a pass by Bergkamp to give Arsenal a 2 goal margin after 78 mins.
 ham	You've already got a flaky parent. It'snot supposed to be the child's job to support the parent...not until they're The Ride age anyway. I'm supposed to be there to support you. And now i've hurt you. unintentional. But hurt nonetheless.
-ham	We took hooch for a walk toaday and i fell over! Splat! Grazed my knees and everything! Should have stayed at home! See you tomorrow! 
+ham	We took hooch for a walk toaday and i fell over! Splat! Grazed my knees and everything! Should have stayed at home! See you tomorrow!
 ham	Just dropped em off, omw back now
 spam	This is the 2nd time we have tried 2 contact u. U have won the 750 Pound prize. 2 claim is easy, call 08712101358 NOW! Only 10p per min. BT-national-rate
 ham	Sitting in mu waiting for everyone to get out of my suite so I can take a shower
@@ -4922,8 +4922,8 @@ ham	Re your call; You didn't see my facebook huh?
 ham	G says you never answer your texts, confirm/deny
 ham	Its so common hearin How r u? Wat r u doing? How was ur day? So let me ask u something different. Did u smile today? If not, do it now.... Gud evng.
 ham	Hi Dear Call me its urgnt. I don't know whats your problem. You don't want to work or if you have any other problem at least tell me. Wating for your reply.
-ham	Oh yah... We never cancel leh... Haha 
-ham	We can go 4 e normal pilates after our intro...  
+ham	Oh yah... We never cancel leh... Haha
+ham	We can go 4 e normal pilates after our intro...
 ham	Ok... Let u noe when i leave my house.
 ham	Oh yes, why is it like torture watching england?
 ham	Wanna do some art?! :D
@@ -5002,9 +5002,9 @@ ham	Hmph. Go head, big baller.
 ham	Well its not like you actually called someone a punto. That woulda been worse.
 ham	Nope. Since ayo travelled, he has forgotten his guy
 ham	You still around? Looking to pick up later
-spam	CDs 4u: Congratulations ur awarded £500 of CD gift vouchers or £125 gift guaranteed & Freeentry 2 £100 wkly draw xt MUSIC to 87066 TnCs www.ldew.com1win150ppmx3age16 
+spam	CDs 4u: Congratulations ur awarded £500 of CD gift vouchers or £125 gift guaranteed & Freeentry 2 £100 wkly draw xt MUSIC to 87066 TnCs www.ldew.com1win150ppmx3age16
 ham	There's someone here that has a year  &lt;#&gt;  toyota camry like mr olayiwola's own. Mileage is  &lt;#&gt; k.its clean but i need to know how much will it sell for. If i can raise the dough for it how soon after landing will it sell. Holla back.
-ham	Guess which pub im in? Im as happy as a pig in clover or whatever the saying is! 
+ham	Guess which pub im in? Im as happy as a pig in clover or whatever the saying is!
 ham	ILL B DOWN SOON
 ham	Oh k. . I will come tomorrow
 ham	Go fool dont cheat others ok
@@ -5015,7 +5015,7 @@ ham	U attend ur driving lesson how many times a wk n which day?
 ham	Uncle G, just checking up on you. Do have a rewarding month
 ham	Hello boytoy ! Geeee ... I'm missing you today. I like to send you a tm and remind you I'm thinking of you ... And you are loved ... *loving kiss*
 ham	I think the other two still need to get cash but we can def be ready by 9
-ham	Hey gals...U all wanna meet 4 dinner at nìte? 
+ham	Hey gals...U all wanna meet 4 dinner at nìte?
 spam	Dear 0776xxxxxxx U've been invited to XCHAT. This is our final attempt to contact u! Txt CHAT to 86688 150p/MsgrcvdHG/Suite342/2Lands/Row/W1J6HL LDN 18yrs
 ham	Babe ! What are you doing ? Where are you ? Who are you talking to ? Do you think of me ? Are you being a good boy? Are you missing me? Do you love me ?
 ham	Great! How is the office today?
@@ -5066,7 +5066,7 @@ ham	Ok i also wan 2 watch e 9 pm show...
 ham	I dunno lei... Like dun haf...
 ham	But your brother transfered only  &lt;#&gt;  +  &lt;#&gt; . Pa.
 ham	I calls you later. Afternoon onwords mtnl service get problem in south mumbai. I can hear you but you cann't listen me.
-spam	83039 62735=£450 UK Break AccommodationVouchers terms & conditions apply. 2 claim you mustprovide your claim number which is 15541 
+spam	83039 62735=£450 UK Break AccommodationVouchers terms & conditions apply. 2 claim you mustprovide your claim number which is 15541
 ham	Talk to g and x about that
 ham	Hai dear friends... This is my new &amp; present number..:) By Rajitha Raj (Ranju)
 spam	5p 4 alfie Moon's Children in need song on ur mob. Tell ur m8s. Txt Tone charity to 8007 for Nokias or Poly charity for polys: zed 08701417012 profit 2 charity.
@@ -5096,12 +5096,12 @@ ham	My fri ah... Okie lor,goin 4 my drivin den go shoppin after tt...
 ham	Gokila is talking with you aha:)
 ham	Hi Shanil,Rakhesh here.thanks,i have exchanged the uncut diamond stuff.leaving back. Excellent service by Dino and Prem.
 ham	K.k.this month kotees birthday know?
-ham	But i'm really really broke oh. No amount is too small even  &lt;#&gt; 
+ham	But i'm really really broke oh. No amount is too small even  &lt;#&gt;
 ham	Sorry about that this is my mates phone and i didnt write it love Kate
 spam	TheMob>Hit the link to get a premium Pink Panther game, the new no. 1 from Sugababes, a crazy Zebra animation or a badass Hoody wallpaper-all 4 FREE!
 ham	Ah, well that confuses things, doesnt it? I thought was friends with now. Maybe i did the wrong thing but i already sort of invited -tho he may not come cos of money.
 ham	Aight, call me once you're close
-ham	Nope thats fine. I might have a nap tho! 
+ham	Nope thats fine. I might have a nap tho!
 spam	This msg is for your mobile content order It has been resent as previous attempt failed due to network error Queries to customersqueries@netvision.uk.com
 ham	In other news after hassling me to get him weed for a week andres has no money. HAUGHAIGHGTUJHYGUJ
 ham	A Boy loved a gal. He propsd bt she didnt mind. He gv lv lttrs, Bt her frnds threw thm. Again d boy decided 2 aproach d gal , dt time a truck was speeding towards d gal. Wn it was about 2 hit d girl,d boy ran like hell n saved her. She asked 'hw cn u run so fast?' D boy replied "Boost is d secret of my energy" n instantly d girl shouted "our energy" n Thy lived happily 2gthr drinking boost evrydy Moral of d story:- I hv free msgs:D;): gud ni8
@@ -5112,11 +5112,11 @@ ham	The sign of maturity is not when we start saying big things.. But actually i
 ham	Oh you got many responsibilities.
 spam	You have 1 new message. Please call 08715205273
 ham	I've reached sch already...
-spam	December only! Had your mobile 11mths+? You are entitled to update to the latest colour camera mobile for Free! Call The Mobile Update VCo FREE on 08002986906 
+spam	December only! Had your mobile 11mths+? You are entitled to update to the latest colour camera mobile for Free! Call The Mobile Update VCo FREE on 08002986906
 ham	U definitely need a module from e humanities dis sem izzit? U wan 2 take other modules 1st?
 ham	Argh why the fuck is nobody in town ;_;
 spam	Get 3 Lions England tone, reply lionm 4 mono or lionp 4 poly. 4 more go 2 www.ringtones.co.uk, the original n best. Tones 3GBP network operator rates apply.
-ham	Thanks. Fills me with complete calm and reassurance! 
+ham	Thanks. Fills me with complete calm and reassurance!
 ham	Aslamalaikkum....insha allah tohar beeen muht albi mufti mahfuuz...meaning same here....
 ham	Are you driving or training?
 ham	Lol for real. She told my dad I have cancer
@@ -5132,13 +5132,13 @@ ham	Wot about on wed nite I am 3 then but only til 9!
 ham	Rose for red,red for blood,blood for heart,heart for u. But u for me.... Send tis to all ur friends.. Including me.. If u like me.. If u get back, 1-u r poor in relation! 2-u need some 1 to support 3-u r frnd 2 many 4-some1 luvs u 5+- some1 is praying god to marry u.:-) try it....
 ham	Any way where are you and what doing.
 ham	That sucks. I'll go over so u can do my hair. You'll do it free right?
-ham	it's still not working. And this time i also tried adding zeros. That was the savings. The checking is  &lt;#&gt; 
+ham	it's still not working. And this time i also tried adding zeros. That was the savings. The checking is  &lt;#&gt;
 ham	Hmm... Dunno leh, mayb a bag 4 goigng out dat is not too small. Or jus anything except perfume, smth dat i can keep.
 ham	Sday only joined.so training we started today:)
 ham	Sorry * was at the grocers.
 ham	There are some nice pubs near here or there is Frankie n Bennys near the warner cinema?
 spam	YOU VE WON! Your 4* Costa Del Sol Holiday or £5000 await collection. Call 09050090044 Now toClaim. SAE, TC s, POBox334, Stockport, SK38xh, Cost£1.50/pm, Max10mins
-ham	Yup... I havent been there before... You want to go for the yoga? I can call up to book 
+ham	Yup... I havent been there before... You want to go for the yoga? I can call up to book
 ham	Oh shut it. Omg yesterday I had a dream that I had 2 kids both boys. I was so pissed. Not only about the kids but them being boys. I even told mark in my dream that he was changing diapers cause I'm not getting owed in the face.
 ham	Yeah I imagine he would be really gentle. Unlike the other docs who treat their patients like turkeys.
 spam	FREE for 1st week! No1 Nokia tone 4 ur mobile every week just txt NOKIA to 8077 Get txting and tell ur mates. www.getzed.co.uk POBox 36504 W45WQ 16+ norm150p/tone
@@ -5177,9 +5177,9 @@ ham	U 2.
 ham	Water logging in desert. Geoenvironmental implications.
 ham	Raji..pls do me a favour. Pls convey my Birthday wishes to Nimya. Pls. Today is her birthday.
 ham	Company is very good.environment is terrific and food is really nice:)
-ham	Very strange.  and  are watching the 2nd one now but i'm in bed. Sweet dreams, miss u 
+ham	Very strange.  and  are watching the 2nd one now but i'm in bed. Sweet dreams, miss u
 spam	SMS AUCTION - A BRAND NEW Nokia 7250 is up 4 auction today! Auction is FREE 2 join & take part! Txt NOKIA to 86021 now!
-ham	Hi hope u r both ok, he said he would text and he hasn't, have u seen him, let me down gently please 
+ham	Hi hope u r both ok, he said he would text and he hasn't, have u seen him, let me down gently please
 ham	Babe! I fucking love you too !! You know? Fuck it was so good to hear your voice. I so need that. I crave it. I can't get enough. I adore you, Ahmad *kisses*
 ham	K sure am in my relatives home. Sms me de. Pls:-)
 ham	I sent them. Do you like?
@@ -5196,7 +5196,7 @@ ham	Oh oh... Den muz change plan liao... Go back have to yan jiu again...
 ham	It's wylie, you in tampa or sarasota?
 ham	Ok... Take ur time n enjoy ur dinner...
 ham	Darren was saying dat if u meeting da ge den we dun meet 4 dinner. Cos later u leave xy will feel awkward. Den u meet him 4 lunch lor.
-spam	Spook up your mob with a Halloween collection of a logo & pic message plus a free eerie tone, txt CARD SPOOK to 8007 zed 08701417012150p per logo/pic 
+spam	Spook up your mob with a Halloween collection of a logo & pic message plus a free eerie tone, txt CARD SPOOK to 8007 zed 08701417012150p per logo/pic
 ham	I like cheap! But i‘m happy to splash out on the wine if it makes you feel better..
 ham	She.s fine. I have had difficulties with her phone. It works with mine. Can you pls send her another friend request.
 ham	Ugh my leg hurts. Musta overdid it on mon.
@@ -5237,7 +5237,7 @@ ham	Hey what how about your project. Started aha da.
 ham	Ok cool. See ya then.
 ham	Am on the uworld site. Am i buying the qbank only or am i buying it with the self assessment also?
 ham	Your opinion about me? 1. Over 2. Jada 3. Kusruthi 4. Lovable 5. Silent 6. Spl character 7. Not matured 8. Stylish 9. Simple Pls reply..
-spam	Someonone you know is trying to contact you via our dating service! To find out who it could be call from your mobile or landline 09064015307 BOX334SK38ch 
+spam	Someonone you know is trying to contact you via our dating service! To find out who it could be call from your mobile or landline 09064015307 BOX334SK38ch
 ham	Yeah I can still give you a ride
 ham	Jay wants to work out first, how's 4 sound?
 ham	Gud gud..k, chikku tke care.. sleep well gud nyt
@@ -5269,7 +5269,7 @@ ham	Gud ni8.swt drms.take care
 ham	HI DARLIN ITS KATE ARE U UP FOR DOIN SOMETHIN TONIGHT? IM GOING TO A PUB CALLED THE SWAN OR SOMETHING WITH MY PARENTS FOR ONE DRINK SO PHONE ME IF U CAN
 ham	Anything lar then ü not going home 4 dinner?
 ham	"ER, ENJOYIN INDIANS AT THE MO..yeP. SaLL gOoD HehE ;> hows bout u shexy? Pete Xx"
-spam	If you don't, your prize will go to another customer. T&C at www.t-c.biz 18+ 150p/min Polo Ltd Suite 373 London W1J 6HL Please call back if busy 
+spam	If you don't, your prize will go to another customer. T&C at www.t-c.biz 18+ 150p/min Polo Ltd Suite 373 London W1J 6HL Please call back if busy
 ham	Did u fix the teeth?if not do it asap.ok take care.
 ham	So u wan 2 come for our dinner tonight a not?
 ham	Hello.How u doing?What u been up 2?When will u b moving out of the flat, cos I will need to arrange to pick up the lamp, etc. Take care. Hello caroline!
@@ -5294,7 +5294,7 @@ ham	Dear where you. Call me
 ham	Xy trying smth now. U eat already? We havent...
 spam	Urgent! Please call 09061213237 from landline. £5000 cash or a luxury 4* Canary Islands Holiday await collection. T&Cs SAE PO Box 177. M227XY. 150ppm. 16+
 ham	I donno its in your genes or something
-spam	XMAS iscoming & ur awarded either £500 CD gift vouchers & free entry 2 r £100 weekly draw txt MUSIC to 87066 TnC www.Ldew.com1win150ppmx3age16subscription 
+spam	XMAS iscoming & ur awarded either £500 CD gift vouchers & free entry 2 r £100 weekly draw txt MUSIC to 87066 TnC www.Ldew.com1win150ppmx3age16subscription
 ham	Alex says he's not ok with you not being ok with it
 ham	Are u coming to the funeral home
 ham	My darling sister. How are you doing. When's school resuming. Is there a minimum wait period before you reapply? Do take care
@@ -5369,7 +5369,7 @@ spam	Camera - You are awarded a SiPix Digital Camera! call 09061221066 fromm lan
 spam	A £400 XMAS REWARD IS WAITING FOR YOU! Our computer has randomly picked you from our loyal mobile customers to receive a £400 reward. Just call 09066380611
 ham	Just trying to figure out when I'm suppose to see a couple different people this week. We said we'd get together but I didn't set dates
 spam	IMPORTANT MESSAGE. This is a final contact attempt. You have important messages waiting out our customer claims dept. Expires 13/4/04. Call 08717507382 NOW!
-ham	Hi mom we might be back later than  &lt;#&gt; 
+ham	Hi mom we might be back later than  &lt;#&gt;
 spam	dating:i have had two of these. Only started after i sent a text to talk sport radio last week. Any connection do you think or coincidence?
 ham	Lol, oh you got a friend for the dog ?
 ham	Ok., is any problem to u frm him? Wats matter?
@@ -5483,7 +5483,7 @@ ham	Really do hope the work doesnt get stressful. Have a gr8 day.
 ham	Have you seen who's back at Holby?!
 ham	Shall call now dear having food
 spam	URGENT We are trying to contact you Last weekends draw shows u have won a £1000 prize GUARANTEED Call 09064017295 Claim code K52 Valid 12hrs 150p pm
-ham	So li hai... Me bored now da lecturer repeating last weeks stuff waste time... 
+ham	So li hai... Me bored now da lecturer repeating last weeks stuff waste time...
 ham	, ,  and  picking them up from various points | going 2 yeovil | and they will do the motor project 4 3 hours | and then u take them home. || 12 2 5.30 max. || Very easy
 ham	Also fuck you and your family for going to rhode island or wherever the fuck and leaving me all alone the week I have a new bong &gt;:(
 ham	Ofcourse I also upload some songs
@@ -5514,7 +5514,7 @@ ham	I went to project centre
 ham	It‘s reassuring, in this crazy world.
 ham	Just making dinner, you ?
 ham	Yes. Please leave at  &lt;#&gt; . So that at  &lt;#&gt;  we can leave
-ham	Oh... Okie lor...We go on sat... 
+ham	Oh... Okie lor...We go on sat...
 ham	You are a great role model. You are giving so much and i really wish each day for a miracle but God as a reason for everything and i must say i wish i knew why but i dont. I've looked up to you since i was young and i still do. Have a great day.
 ham	Ya, i'm referin to mei's ex wat... No ah, waitin 4 u to treat, somebody shld b rich liao...So gd, den u dun have to work frm tmr onwards...
 ham	Miles and smiles r made frm same letters but do u know d difference..? smile on ur face keeps me happy even though I am miles away from u.. :-)keep smiling.. Good nyt
@@ -5533,7 +5533,7 @@ ham	What about this one then.
 ham	I think that tantrum's finished so yeah I'll be by at some point
 ham	Compliments to you. Was away from the system. How your side.
 ham	happened here while you were adventuring
-ham	Hey chief, can you give me a bell when you get this. Need to talk to you about this royal visit on the 1st june. 
+ham	Hey chief, can you give me a bell when you get this. Need to talk to you about this royal visit on the 1st june.
 ham	Ok which your another number
 ham	I know you are thinkin malaria. But relax, children cant handle malaria. She would have been worse and its gastroenteritis. If she takes enough to replace her loss her temp will reduce. And if you give her malaria meds now she will just vomit. Its a self limiting illness she has which means in a few days it will completely stop
 ham	Aiyah ok wat as long as got improve can already wat...

--- a/examples/datasets/spam/readme
+++ b/examples/datasets/spam/readme
@@ -4,7 +4,7 @@ SMS Spam Collection v.1
 1. DESCRIPTION
 --------------
 
-The SMS Spam Collection v.1 (hereafter the corpus) is a set of SMS tagged messages that have been collected for SMS Spam research. It contains one set of SMS messages in English of 5,574 messages, tagged acording being ham (legitimate) or spam. 
+The SMS Spam Collection v.1 (hereafter the corpus) is a set of SMS tagged messages that have been collected for SMS Spam research. It contains one set of SMS messages in English of 5,574 messages, tagged acording being ham (legitimate) or spam.
 
 1.1. Compilation
 ----------------

--- a/examples/main.py
+++ b/examples/main.py
@@ -7,14 +7,12 @@ from sms_spam_data_module import SmsSpamDataModule
 from toxic_comment_data_module import ToxicCommentDataModule
 
 from sheepy.data_modules.base_csv_data_module import BaseCSVDataModule
-from sheepy.data_modules.multi_label_csv_data_module import MultiLabelCSVDataModule
 from sheepy.experiment.base_experiment import Experiment
 from sheepy.experiment.sweep_experiment import SweepExperiment
 from sheepy.models import MODEL_MAPPING
 
 DATA_MODULE_MAPPING = {
     "base_csv_data_module": BaseCSVDataModule,
-    "toxic_comment_data_module": MultiLabelCSVDataModule,
     "sms_spam_data_module": SmsSpamDataModule,
     "toxic_comment_data_module": ToxicCommentDataModule,
     "semeval_data_module": SemEvalSentimentDataModule,

--- a/examples/main.py
+++ b/examples/main.py
@@ -13,40 +13,78 @@ from sheepy.experiment.sweep_experiment import SweepExperiment
 from sheepy.models import MODEL_MAPPING
 
 DATA_MODULE_MAPPING = {
-    'base_csv_data_module': BaseCSVDataModule,
-    'toxic_comment_data_module': MultiLabelCSVDataModule,
-    'sms_spam_data_module': SmsSpamDataModule,
-    'toxic_comment_data_module': ToxicCommentDataModule,
-    'semeval_data_module': SemEvalSentimentDataModule,
+    "base_csv_data_module": BaseCSVDataModule,
+    "toxic_comment_data_module": MultiLabelCSVDataModule,
+    "sms_spam_data_module": SmsSpamDataModule,
+    "toxic_comment_data_module": ToxicCommentDataModule,
+    "semeval_data_module": SemEvalSentimentDataModule,
 }
+
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
 
     # The config file below specifies values for all arguments listed in this function
     # TODO - some these can be moved to a config, such as fp16
-    parser.add_argument("--config", required=True, type=str,
-                        help="Location of experiment config profile JSON.")
-    parser.add_argument("--time", type=str, required=True,
-                        help="current time str, populated by shell most likely, in format YYYY_MM_dd__hh_mm_ss_UTC")
-    parser.add_argument("--fp16", action="store_true",
-                        help="Enables 16-bit floating-point precision during training on GPU's if available")
-    parser.add_argument("--data_format", type=str, default="csv",
-                        help="Data format of input file/s, must be either csv or json")
-    parser.add_argument("--evaluate", action="store_true",
-                        help="Runs the model in batch evaluation mode on a text file instead of the train/val/test mode.")
-    parser.add_argument("--evaluate_batch_file", type=str, default=None,
-                        help="Location of the text file with which to run batch evaluation.")
-    parser.add_argument("--evaluate_live", action="store_true",
-                        help="Runs the model in raw input evaluation mode from the shell instead of the train/val/test mode or batch evaluation mode")
-    parser.add_argument("--tune", action="store_true",
-                        help="Runs the model in tune/sweep mode as per the sweep argument of the config file.")
-    parser.add_argument("--output_dir", type=str, default=None,
-                        help="In training mode, this is the name of the directory used to output the results of your experiment. In evaluation mode, this is the directory where you want to load your experiment.")
-    parser.add_argument("--output_key", type=str, default=None,
-                        help="Name of the output column or dict key. Used only in evaluation mode")
-    parser.add_argument("--pretrained_dir", type=str, default=None,
-                        help="Name of the directory with pretrained model. Used only in evaluation mode")
+    parser.add_argument(
+        "--config", required=True, type=str, help="Location of experiment config profile JSON."
+    )
+    parser.add_argument(
+        "--time",
+        type=str,
+        required=True,
+        help="current time str, populated by shell most likely, in format YYYY_MM_dd__hh_mm_ss_UTC",
+    )
+    parser.add_argument(
+        "--fp16",
+        action="store_true",
+        help="Enables 16-bit floating-point precision during training on GPU's if available",
+    )
+    parser.add_argument(
+        "--data_format",
+        type=str,
+        default="csv",
+        help="Data format of input file/s, must be either csv or json",
+    )
+    parser.add_argument(
+        "--evaluate",
+        action="store_true",
+        help="Runs the model in batch evaluation mode on a text file instead of the train/val/test mode.",
+    )
+    parser.add_argument(
+        "--evaluate_batch_file",
+        type=str,
+        default=None,
+        help="Location of the text file with which to run batch evaluation.",
+    )
+    parser.add_argument(
+        "--evaluate_live",
+        action="store_true",
+        help="Runs the model in raw input evaluation mode from the shell instead of the train/val/test mode or batch evaluation mode",
+    )
+    parser.add_argument(
+        "--tune",
+        action="store_true",
+        help="Runs the model in tune/sweep mode as per the sweep argument of the config file.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default=None,
+        help="In training mode, this is the name of the directory used to output the results of your experiment. In evaluation mode, this is the directory where you want to load your experiment.",
+    )
+    parser.add_argument(
+        "--output_key",
+        type=str,
+        default=None,
+        help="Name of the output column or dict key. Used only in evaluation mode",
+    )
+    parser.add_argument(
+        "--pretrained_dir",
+        type=str,
+        default=None,
+        help="Name of the directory with pretrained model. Used only in evaluation mode",
+    )
 
     return parser
 
@@ -55,7 +93,7 @@ def main():
     parser = get_parser()
     args, _ = parser.parse_known_args()
 
-    with open(args.config, 'r') as f:
+    with open(args.config, "r") as f:
         config = json.load(f)
         try:
             data_module_key = config["experiment"]["data_module"]
@@ -64,11 +102,13 @@ def main():
             model = MODEL_MAPPING[model_key]
         except KeyError:
             raise KeyError(
-                "You must pass both a 'data_module' and 'model' argument to the config file under the 'experiment' key object, and these must be mapped in the module_mappings.py file")
+                "You must pass both a 'data_module' and 'model' argument to the config file under the 'experiment' key object, and these must be mapped in the module_mappings.py file"
+            )
 
     if args.tune and args.evaluate:
         raise ValueError(
-            "You cannot run the model with both tune and evaluate mode turned on. Pick one or the other, or neither if you want to just train.")
+            "You cannot run the model with both tune and evaluate mode turned on. Pick one or the other, or neither if you want to just train."
+        )
 
     parser = data_module.add_model_specific_args(parser)
     parser = model.add_model_specific_args(parser)
@@ -101,5 +141,5 @@ def main():
             experiment.test()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/semeval_sentiment_data_module.py
+++ b/examples/semeval_sentiment_data_module.py
@@ -18,9 +18,14 @@ class SemEvalSentimentDataModule(BaseCSVDataModule):
 
     def __init__(self, args):
         super().__init__(args)
-        self.all_dataframes, self.train_dataframes, self.val_dataframes, self.test_dataframes = None, None, None, None
+        self.all_dataframes, self.train_dataframes, self.val_dataframes, self.test_dataframes = (
+            None,
+            None,
+            None,
+            None,
+        )
 
-    def prepare_data(self, stage: str=None):
+    def prepare_data(self, stage: str = None):
         """[summary]
 
         Args:
@@ -30,22 +35,28 @@ class SemEvalSentimentDataModule(BaseCSVDataModule):
         if self.evaluate:
             return
 
-        if not os.path.isfile(self.args.train_data_dir) or not self.args.train_data_dir.endswith(".csv"):
+        if not os.path.isfile(self.args.train_data_dir) or not self.args.train_data_dir.endswith(
+            ".csv"
+        ):
             self.logger.info("Downloading semeval train data")
-            KEY = 'datasets/semeval/semeval-2017-train.csv'
+            KEY = "datasets/semeval/semeval-2017-train.csv"
             _ = download_resource(KEY, self.args.train_data_dir)
 
-        if not os.path.isfile(self.args.val_data_dir) or not self.args.val_data_dir.endswith(".csv"):
+        if not os.path.isfile(self.args.val_data_dir) or not self.args.val_data_dir.endswith(
+            ".csv"
+        ):
             self.logger.info("Downloading semeval val data")
-            KEY = 'datasets/semeval/semeval-2017-val.csv'
+            KEY = "datasets/semeval/semeval-2017-val.csv"
             _ = download_resource(KEY, self.args.val_data_dir)
 
-        if not os.path.isfile(self.args.test_data_dir) or not self.args.test_data_dir.endswith(".csv"):
+        if not os.path.isfile(self.args.test_data_dir) or not self.args.test_data_dir.endswith(
+            ".csv"
+        ):
             self.logger.info("Downloading semeval test data")
-            KEY = 'datasets/semeval/semeval-2017-test.csv'
+            KEY = "datasets/semeval/semeval-2017-test.csv"
             _ = download_resource(KEY, self.args.test_data_dir)
 
-    def setup(self, stage: str=None):
+    def setup(self, stage: str = None):
         """[summary]
 
         Args:
@@ -57,8 +68,12 @@ class SemEvalSentimentDataModule(BaseCSVDataModule):
         self.train_dataframes = self._read_csv_directory(self.args.train_data_dir)
         self.val_dataframes = self._read_csv_directory(self.args.val_data_dir)
         self.test_dataframes = self._read_csv_directory(self.args.test_data_dir)
-        self._train_dataset, self._val_dataset, self._test_dataset = self.split_dataframes(train_dataframes=self.train_dataframes, val_dataframes=self.val_dataframes, test_dataframes=self.test_dataframes, stage=stage)
-
+        self._train_dataset, self._val_dataset, self._test_dataset = self.split_dataframes(
+            train_dataframes=self.train_dataframes,
+            val_dataframes=self.val_dataframes,
+            test_dataframes=self.test_dataframes,
+            stage=stage,
+        )
 
     def _read_csv_directory(self, csv_path: str) -> List[pd.DataFrame]:
         """Given a directory of csv files, or a single csv file, return a list of pandas dataframes containing
@@ -82,7 +97,12 @@ class SemEvalSentimentDataModule(BaseCSVDataModule):
         for csv_file in csvs:
             fpath = csv_file if csv_file.endswith(".csv") else os.path.join(csv_path, csv_file)
             df = read_csv_text_classifier(
-                fpath, evaluate=self.evaluate, delimiter="\t", label_cols=self.label_col, text_col=self.text_col)
+                fpath,
+                evaluate=self.evaluate,
+                delimiter="\t",
+                label_cols=self.label_col,
+                text_col=self.text_col,
+            )
             out_dfs.append(df)
         return out_dfs
 
@@ -97,22 +117,37 @@ class SemEvalSentimentDataModule(BaseCSVDataModule):
         """
         if self.text_col is None:
             raise NotImplementedError(
-                "To use the default collate function you need a text column in your hparams config under the key 'text', or some other way of preparing your sample from other functions.")
-        return single_text_collate_function(sample,
-                                            self.text_col,
-                                            self.label_col,
-                                            self.sample_id_col,
-                                            self.tokenizer,
-                                            self.label_encoder,
-                                            evaluate=self.evaluate)
+                "To use the default collate function you need a text column in your hparams config under the key 'text', or some other way of preparing your sample from other functions."
+            )
+        return single_text_collate_function(
+            sample,
+            self.text_col,
+            self.label_col,
+            self.sample_id_col,
+            self.tokenizer,
+            self.label_encoder,
+            evaluate=self.evaluate,
+        )
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
-        parser.add_argument("--train_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the training csvs, or alternatively a single train csv file")
-        parser.add_argument("--val_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the validation csvs, or alternatively a single validation csv file")
-        parser.add_argument("--test_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the test csvs, or alternatively a single test csv file")
+        """Return the argument parser with necessary args for this class appended to it"""
+        parser.add_argument(
+            "--train_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the training csvs, or alternatively a single train csv file",
+        )
+        parser.add_argument(
+            "--val_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the validation csvs, or alternatively a single validation csv file",
+        )
+        parser.add_argument(
+            "--test_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the test csvs, or alternatively a single test csv file",
+        )
         return parser

--- a/examples/sms_spam_data_module.py
+++ b/examples/sms_spam_data_module.py
@@ -16,7 +16,12 @@ class SmsSpamDataModule(BaseCSVDataModule):
 
     def __init__(self, args):
         super().__init__(args)
-        self.all_dataframes, self.train_dataframes, self.val_dataframes, self.test_dataframes = None, None, None, None
+        self.all_dataframes, self.train_dataframes, self.val_dataframes, self.test_dataframes = (
+            None,
+            None,
+            None,
+            None,
+        )
 
     def _read_dataset(self) -> pd.DataFrame:
         """Reads the dataset file that contains all the SMS spam, and returns a list of tuples
@@ -30,9 +35,11 @@ class SmsSpamDataModule(BaseCSVDataModule):
         with open(os.path.join(self.args.data_dir, "SMSSpamCollection"), "r") as data_file:
             for line in data_file:
                 line = line.strip().split("\t")
-                assert len(line)==2
+                assert len(line) == 2
                 label, text = line[0], line[1]
-                dataset = dataset.append({self.text_col: text, self.label_col: label}, ignore_index=True)
+                dataset = dataset.append(
+                    {self.text_col: text, self.label_col: label}, ignore_index=True
+                )
 
         return dataset
 
@@ -50,7 +57,7 @@ class SmsSpamDataModule(BaseCSVDataModule):
                 dataset = dataset.append({self.text_col: text}, ignore_index=True)
         return dataset
 
-    def prepare_data(self, stage: str=None):
+    def prepare_data(self, stage: str = None):
         """[summary]
 
         Args:
@@ -64,13 +71,15 @@ class SmsSpamDataModule(BaseCSVDataModule):
 
         if not os.path.exists(os.path.join(self.args.data_dir, "SMSSpamCollection")):
             self.logger.info("Downloading SMS Spam Dataset")
-            KEY = 'datasets/spam/SMSSpamCollection'
+            KEY = "datasets/spam/SMSSpamCollection"
             dst = os.path.join(self.args.data_dir, "SMSSpamCollection")
             _ = download_resource(KEY, dst)
 
-        assert os.path.exists(os.path.join(self.args.data_dir, "SMSSpamCollection")), "Failed to find SMSSpamCollection in data_dir {}".format(self.args.data_dir)
+        assert os.path.exists(
+            os.path.join(self.args.data_dir, "SMSSpamCollection")
+        ), "Failed to find SMSSpamCollection in data_dir {}".format(self.args.data_dir)
 
-    def setup(self, stage: str=None):
+    def setup(self, stage: str = None):
         """[summary]
 
         Args:
@@ -81,12 +90,16 @@ class SmsSpamDataModule(BaseCSVDataModule):
             self.all_dataframes = []
             for f in os.listdir(self.args.data_dir):
                 if f.endswith(".txt"):
-                    self.all_dataframes.append(self._read_evaluation_file(os.path.join(self.args.data_dir, f)))
+                    self.all_dataframes.append(
+                        self._read_evaluation_file(os.path.join(self.args.data_dir, f))
+                    )
         else:
             self.logger.info("Reading dataset...")
             self.all_dataframes = [self._read_dataset()]
 
-        self._train_dataset, self._val_dataset, self._test_dataset = self.split_dataframes(all_dataframes=self.all_dataframes, stage=stage)
+        self._train_dataset, self._val_dataset, self._test_dataset = self.split_dataframes(
+            all_dataframes=self.all_dataframes, stage=stage
+        )
 
     def prepare_sample(self, sample: list) -> CollatedSample:
         """
@@ -97,17 +110,23 @@ class SmsSpamDataModule(BaseCSVDataModule):
             - dictionary with the expected model inputs.
             - dictionary with the expected target labels.
         """
-        return single_text_collate_function(sample,
-                                            self.text_col,
-                                            self.label_col,
-                                            self.sample_id_col,
-                                            self.tokenizer,
-                                            self.label_encoder,
-                                            evaluate=self.evaluate)
+        return single_text_collate_function(
+            sample,
+            self.text_col,
+            self.label_col,
+            self.sample_id_col,
+            self.tokenizer,
+            self.label_encoder,
+            evaluate=self.evaluate,
+        )
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
-        parser.add_argument("--data_dir", type=str, required=True,
-                            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file")
+        """Return the argument parser with necessary args for this class appended to it"""
+        parser.add_argument(
+            "--data_dir",
+            type=str,
+            required=True,
+            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file",
+        )
         return parser

--- a/examples/toxic_comment_data_module.py
+++ b/examples/toxic_comment_data_module.py
@@ -75,7 +75,7 @@ class ToxicCommentDataModule(MultiLabelCSVDataModule):
             [type]: [description]
         """
         self.all_dataframes = None
-        if stage == "fit" or stage == None:
+        if stage == "fit" or stage is None:
             self.train_dataframes = self._read_csv_directory(
                 os.path.join(self.args.data_dir, "train.csv")
             )

--- a/examples/toxic_comment_data_module.py
+++ b/examples/toxic_comment_data_module.py
@@ -12,6 +12,7 @@ class ToxicCommentDataModule(MultiLabelCSVDataModule):
     """
     DataLoader based on the multilabel csv data module provoiding an example of multi label ETL
     """
+
     def __init__(self, args):
         super().__init__(args)
         self._train_dataset, self._val_dataset, self._test_dataset = None, None, None
@@ -46,24 +47,23 @@ class ToxicCommentDataModule(MultiLabelCSVDataModule):
 
         if not os.path.exists(train_dst):
             self.logger.info("Downloading train.csv")
-            KEY = 'datasets/toxic_comments/train.csv'
+            KEY = "datasets/toxic_comments/train.csv"
             _ = download_resource(KEY, train_dst)
 
         if not os.path.exists(test_dst):
             self.logger.info("Downloading test_filtered.csv")
-            KEY = 'datasets/toxic_comments/test_filtered.csv'
+            KEY = "datasets/toxic_comments/test_filtered.csv"
             _ = download_resource(KEY, test_dst)
 
         if not os.path.exists(train_dst):
             self.logger.info("Downloading train_sample.csv")
-            KEY = 'datasets/toxic_comments/train_sample.csv'
+            KEY = "datasets/toxic_comments/train_sample.csv"
             _ = download_resource(KEY, train_sample_dst)
 
         if not os.path.exists(test_dst):
             self.logger.info("Downloading test_filtered_sample.csv")
-            KEY = 'datasets/toxic_comments/test_filtered_sample.csv'
+            KEY = "datasets/toxic_comments/test_filtered_sample.csv"
             _ = download_resource(KEY, test_sample_dst)
-
 
     def setup(self, stage=None):
         """[summary]
@@ -76,40 +76,69 @@ class ToxicCommentDataModule(MultiLabelCSVDataModule):
         """
         self.all_dataframes = None
         if stage == "fit" or stage == None:
-            self.train_dataframes = self._read_csv_directory(os.path.join(self.args.data_dir, "train.csv"))
-            self._train_dataset, self._val_dataset, _ = split_dataframes(self.train_dataframes, train_ratio=self.args.hparams['train_ratio'], validation_ratio=self.args.hparams['validation_ratio'], test_ratio=0., shuffle=True)
+            self.train_dataframes = self._read_csv_directory(
+                os.path.join(self.args.data_dir, "train.csv")
+            )
+            self._train_dataset, self._val_dataset, _ = split_dataframes(
+                self.train_dataframes,
+                train_ratio=self.args.hparams["train_ratio"],
+                validation_ratio=self.args.hparams["validation_ratio"],
+                test_ratio=0.0,
+                shuffle=True,
+            )
 
-            #The test set is a bit funky, but we process it separately and remove the unlabeled examples. that's why test_filtered.csv exists
-            self.test_dataframes = self._read_csv_directory(os.path.join(self.args.data_dir, "test_filtered.csv"))
-            _, _, self._test_dataset = split_dataframes(self.test_dataframes, train_ratio=0., validation_ratio=0., test_ratio=1., shuffle=True)
+            # The test set is a bit funky, but we process it separately and remove the unlabeled examples. that's why test_filtered.csv exists
+            self.test_dataframes = self._read_csv_directory(
+                os.path.join(self.args.data_dir, "test_filtered.csv")
+            )
+            _, _, self._test_dataset = split_dataframes(
+                self.test_dataframes,
+                train_ratio=0.0,
+                validation_ratio=0.0,
+                test_ratio=1.0,
+                shuffle=True,
+            )
 
             self._train_dataset = self._resample_positive_rows(self._train_dataset)
 
-            self.logger.info("Dataset split complete. (Total) Dataset Shapes:\n\tTrain: {}\n\tValidation: {}\n\tTest: {}".format(
-                self._train_dataset.shape, self._val_dataset.shape, self._test_dataset.shape))
-
+            self.logger.info(
+                "Dataset split complete. (Total) Dataset Shapes:\n\tTrain: {}\n\tValidation: {}\n\tTest: {}".format(
+                    self._train_dataset.shape, self._val_dataset.shape, self._test_dataset.shape
+                )
+            )
 
             train_label_size_out = "Training Dataset Sample Size For Each Label:\n"
             for label in self.args.hparams["label"]:
-                support = self._train_dataset[self._train_dataset[label]=="1"].shape[0]
-                train_label_size_out += "\t{}: {} samples ({} %)\n".format(label, support, round(100*support/self._train_dataset.shape[0], 4))
+                support = self._train_dataset[self._train_dataset[label] == "1"].shape[0]
+                train_label_size_out += "\t{}: {} samples ({} %)\n".format(
+                    label, support, round(100 * support / self._train_dataset.shape[0], 4)
+                )
             self.logger.info(train_label_size_out)
 
-            self._test_dataset[self.sample_id_col] = range(
-                len(self._test_dataset))
+            self._test_dataset[self.sample_id_col] = range(len(self._test_dataset))
 
-        else: #evaluating
+        else:  # evaluating
             if self._test_dataset is None:
                 for f in os.listdir(self.args.data_dir):
                     if f.endswith(".txt"):
-                        self.test_dataframes.append(self._read_evaluation_file(os.path.join(self.args.data_dir, f)))
+                        self.test_dataframes.append(
+                            self._read_evaluation_file(os.path.join(self.args.data_dir, f))
+                        )
                 self._test_dataset = pd.concat(self.test_dataframes)
                 self._test_dataset[self.sample_id_col] = range(len(self._test_dataset))
-                self.logger.info("In evaluation mode. Dataset Shapes:\n\tTest: {}".format(self._test_dataset.shape))
+                self.logger.info(
+                    "In evaluation mode. Dataset Shapes:\n\tTest: {}".format(
+                        self._test_dataset.shape
+                    )
+                )
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
-        parser.add_argument("--data_dir", type=str, required=False,
-                            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file")
+        """Return the argument parser with necessary args for this class appended to it"""
+        parser.add_argument(
+            "--data_dir",
+            type=str,
+            required=False,
+            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file",
+        )
         return parser

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ setup(
     name=PACKAGE_NAME,
     version=VERSION,
     long_description=README,
-    description='Experiment-tracking wrapper around PyTorch Lightning, Weights & Biases, Pandas, and Huggingface Trasformers that aims at rapid experimentation for common text classification tasks using transformers',
-    author='Rob Sylvester',
-    author_email='robmsylvester@gmail.com',
-    python_requires='>=3.8,<3.10',
+    description="Experiment-tracking wrapper around PyTorch Lightning, Weights & Biases, Pandas, and Huggingface Trasformers that aims at rapid experimentation for common text classification tasks using transformers",
+    author="Rob Sylvester",
+    author_email="robmsylvester@gmail.com",
+    python_requires=">=3.8,<3.10",
     install_requires=[
         "pandas>=1.1.1",
         "torch>=1.6.0",
@@ -38,5 +38,5 @@ setup(
         "torchmetrics==0.6.0",
         "rich>=12.4.1",
     ],
-    packages=find_packages()
+    packages=find_packages(),
 )

--- a/sheepy/common/collate.py
+++ b/sheepy/common/collate.py
@@ -12,11 +12,11 @@ from sheepy.nlp.tokenizer import Tokenizer
 #     inputs: samples and their lengths
 #     targets: labels
 #     ids: sample ids (used to align predicted values with corresponding samples in multi-GPU environment)
-CollatedSample = namedtuple(
-    'CollatedSample', ['inputs', 'targets', 'ids'])
+CollatedSample = namedtuple("CollatedSample", ["inputs", "targets", "ids"])
 
-def _get_sample_list(samples: List[str], sample_size: int=None) -> List[str]:
-    """"Returns a list of samples from a list, without repetition.
+
+def _get_sample_list(samples: List[str], sample_size: int = None) -> List[str]:
+    """ "Returns a list of samples from a list, without repetition.
 
     Args:
         samples (List[str]): a list of strings
@@ -32,12 +32,19 @@ def _get_sample_list(samples: List[str], sample_size: int=None) -> List[str]:
         sample_size = len(samples)
 
     if sample_size > len(samples):
-        raise ValueError("Sampling {} samples isn't possible when only {} are available".format(sample_size, len(samples)))
+        raise ValueError(
+            "Sampling {} samples isn't possible when only {} are available".format(
+                sample_size, len(samples)
+            )
+        )
 
     chosen = random.sample(samples, k=sample_size)
     return chosen
 
-def _concatenate_text_samples(sample: dict, keys: List[str], default_separator: str=".") -> List[str]:
+
+def _concatenate_text_samples(
+    sample: dict, keys: List[str], default_separator: str = "."
+) -> List[str]:
     """Given a sample dicitonary, return a single string of concatenated strings, each of which is a key
     in the list 'keys' for the dictionary. the dictionary, at each of these keys, will have a list of values
     that is as long as the batch length in the current iteration.
@@ -56,14 +63,15 @@ def _concatenate_text_samples(sample: dict, keys: List[str], default_separator: 
     sample_batch_size = len(sample[keys[0]])
     for idx in range(sample_batch_size):
         formatted_sample_string = []
-        sample_strings = [sample[key][idx] for key in keys] #returns a list of length batch_size
+        sample_strings = [sample[key][idx] for key in keys]  # returns a list of length batch_size
         for ss in sample_strings:
             if len(ss):
-                if ss[-1] not in ['?','!','.']:
+                if ss[-1] not in ["?", "!", "."]:
                     ss += default_separator
                 formatted_sample_string.append(ss)
         out_strings.append(" ".join([fss for fss in formatted_sample_string]))
     return out_strings
+
 
 def round_size(size: int):
     """
@@ -75,13 +83,16 @@ def round_size(size: int):
         lowest_power_of_two *= 2
     return lowest_power_of_two
 
-def single_text_collate_function(sample: list,
-                                 text_key: str,
-                                 label_keys: Union[str, List[str]],
-                                 id_key: str,
-                                 tokenizer: Tokenizer,
-                                 label_encoder: LabelEncoder = None,
-                                 evaluate: bool = False) -> CollatedSample:
+
+def single_text_collate_function(
+    sample: list,
+    text_key: str,
+    label_keys: Union[str, List[str]],
+    id_key: str,
+    tokenizer: Tokenizer,
+    label_encoder: LabelEncoder = None,
+    evaluate: bool = False,
+) -> CollatedSample:
     """
     Function that prepares a sample to input the model.
 
@@ -107,7 +118,10 @@ def single_text_collate_function(sample: list,
         tokens, lengths = tokenizer.batch_encode(sample[text_key])
     except KeyError:
         raise KeyError(
-            "Text key {} does not exist in sample. Sample keys are:\n{}".format(text_key, list(sample.keys())))
+            "Text key {} does not exist in sample. Sample keys are:\n{}".format(
+                text_key, list(sample.keys())
+            )
+        )
 
     inputs = {"tokens": tokens, "lengths": lengths}
     targets = {}
@@ -123,7 +137,10 @@ def single_text_collate_function(sample: list,
                 targets = {"labels": label_encoder.batch_encode(sample[label_keys])}
         except KeyError:
             raise KeyError(
-                "Label key {} does not exist in sample. Sample keys are:\n{}".format(label_keys, list(sample.keys())))
+                "Label key {} does not exist in sample. Sample keys are:\n{}".format(
+                    label_keys, list(sample.keys())
+                )
+            )
         except RuntimeError:
             raise Exception("Label encoder found an unknown label.")
 

--- a/sheepy/common/df_ops.py
+++ b/sheepy/common/df_ops.py
@@ -1,4 +1,3 @@
-import json
 import os
 import random
 from copy import deepcopy

--- a/sheepy/common/df_ops.py
+++ b/sheepy/common/df_ops.py
@@ -1,22 +1,23 @@
 import json
 import os
-import pandas as pd
 import random
-import json
-from typing import Any, Dict, List, Union, Tuple
 from copy import deepcopy
+from typing import Any, Dict, List, Tuple, Union
+
+import pandas as pd
 
 # TODO - move this global variable
-SOURCE_FILE = 'source_file'
+SOURCE_FILE = "source_file"
 
-#TODO - docstrings
+# TODO - docstrings
+
 
 def column_exists(col_name: str, my_df: pd.DataFrame):
     """Helper function for readability to check if a column exists in a dataframe"""
     return True if col_name in my_df.columns else False
 
-def read_csv(path: str,
-             filter_cols: List[str]=None) -> pd.DataFrame:
+
+def read_csv(path: str, filter_cols: List[str] = None) -> pd.DataFrame:
     """
     Reads a full comma-separated value file and returns all columns. Some safety checks
 
@@ -33,14 +34,17 @@ def read_csv(path: str,
 
     return df.astype(str)
 
-def read_csv_text_classifier(path: str,
-                             encoding: str="utf-8",
-                             delimiter: str=",",
-                             evaluate: bool = False,
-                             label_cols: Union[str, List[str]] = "label",
-                             text_col: str = "text",
-                             additional_cols: List[str] = None,
-                             names: List[str] = None) -> pd.DataFrame:
+
+def read_csv_text_classifier(
+    path: str,
+    encoding: str = "utf-8",
+    delimiter: str = ",",
+    evaluate: bool = False,
+    label_cols: Union[str, List[str]] = "label",
+    text_col: str = "text",
+    additional_cols: List[str] = None,
+    names: List[str] = None,
+) -> pd.DataFrame:
     """
     Reads a full comma-separated value file that stores, at the minimum, a text column as well as a label column.
 
@@ -76,11 +80,13 @@ def read_csv_text_classifier(path: str,
         for col in labels:
             if not column_exists(col, df):
                 raise ValueError(
-                    "{} not a valid label column in dataset csv at {}".format(col, path))
+                    "{} not a valid label column in dataset csv at {}".format(col, path)
+                )
 
     if text_col is None or not column_exists(text_col, df):
         raise ValueError(
-            f"{text_col} is not a valid text column. Your text column must be a string that exists in the dataframe")
+            f"{text_col} is not a valid text column. Your text column must be a string that exists in the dataframe"
+        )
 
     if evaluate:
         return_df = df  # preserving all columns because in eval mode we have to output all columns
@@ -99,6 +105,7 @@ def read_csv_text_classifier(path: str,
 
     return return_df.astype(str)
 
+
 def add_relative_position(document: pd.DataFrame, index_col=None) -> pd.DataFrame:
     """
     Given a dataframe and a possibly-specified index colummn, otherwise using the default,
@@ -106,15 +113,19 @@ def add_relative_position(document: pd.DataFrame, index_col=None) -> pd.DataFram
     the row index. In other words, if your dataframe has 100 rows, the 50th row would have a relative_position
     of 0.0, and the 25th row would have a relative_position of -0.5.
     """
-    document['temp_dummy'] = range(document.shape[0])
-    document['relative_position'] = (
-        (document['temp_dummy'] / document.shape[0]) * 2) - 1
-    document.drop(columns=['temp_dummy'], inplace=True)
+    document["temp_dummy"] = range(document.shape[0])
+    document["relative_position"] = ((document["temp_dummy"] / document.shape[0]) * 2) - 1
+    document.drop(columns=["temp_dummy"], inplace=True)
     return document
 
 
-def split_dataframes(dataframes: List[pd.DataFrame], train_ratio: float, validation_ratio: float,
-                     test_ratio: float = None, shuffle: bool = True) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+def split_dataframes(
+    dataframes: List[pd.DataFrame],
+    train_ratio: float,
+    validation_ratio: float,
+    test_ratio: float = None,
+    shuffle: bool = True,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     Splits dataframes to train, valid and test dfs according to the provided ratios.
 
@@ -130,10 +141,11 @@ def split_dataframes(dataframes: List[pd.DataFrame], train_ratio: float, validat
         return split_dataframe(dataframes[0], train_ratio, validation_ratio, shuffle)
 
     first_validation_index = round(len(dataframes) * train_ratio)
-    first_test_index = round(
-        len(dataframes) * (train_ratio + validation_ratio))
+    first_test_index = round(len(dataframes) * (train_ratio + validation_ratio))
 
-    if first_validation_index == 0 or (first_validation_index == first_test_index and validation_ratio > 0):
+    if first_validation_index == 0 or (
+        first_validation_index == first_test_index and validation_ratio > 0
+    ):
         # list of dataframes is too short
         dataframe = pd.concat(dataframes)
         return split_dataframe(dataframe, train_ratio, validation_ratio, shuffle)
@@ -145,17 +157,28 @@ def split_dataframes(dataframes: List[pd.DataFrame], train_ratio: float, validat
     validation_dfs = dataframes[first_validation_index:first_test_index]
     test_dfs = dataframes[first_test_index:]
     train = pd.concat(train_dfs)
-    validation = pd.concat(validation_dfs) if len(validation_dfs) else pd.DataFrame(
-        columns=train_dfs[0].columns.tolist())
-    test = pd.concat(test_dfs) if len(test_dfs) else pd.DataFrame(
-        columns=train_dfs[0].columns.tolist())
+    validation = (
+        pd.concat(validation_dfs)
+        if len(validation_dfs)
+        else pd.DataFrame(columns=train_dfs[0].columns.tolist())
+    )
+    test = (
+        pd.concat(test_dfs)
+        if len(test_dfs)
+        else pd.DataFrame(columns=train_dfs[0].columns.tolist())
+    )
 
     # Early check on dataset sizes here should enforce length of each
     return train, validation, test
 
 
-def split_dataframe(df: pd.DataFrame, train_ratio: float, validation_ratio: float, test_ratio: float = None,
-                    shuffle: bool = False):
+def split_dataframe(
+    df: pd.DataFrame,
+    train_ratio: float,
+    validation_ratio: float,
+    test_ratio: float = None,
+    shuffle: bool = False,
+):
     """
     Splits dataframe to train, valid and test dfs according to the provided ratios.
     :param df: dataframe to split
@@ -176,6 +199,7 @@ def split_dataframe(df: pd.DataFrame, train_ratio: float, validation_ratio: floa
 
     return train, validation, test
 
+
 def write_csv_dataset(df: pd.DataFrame, output_path: str):
     if os.path.isdir(output_path):
         for source_file, results in df.groupby(SOURCE_FILE, as_index=False):
@@ -189,10 +213,10 @@ def write_json_dataset(df: pd.DataFrame, output_path: str):
     if os.path.isdir(output_path):
         for source_file, results in df.groupby(SOURCE_FILE, as_index=False):
             results = results.drop(SOURCE_FILE, axis=1)
-            results.to_json(os.path.join(
-                output_path, source_file), orient='records')
+            results.to_json(os.path.join(output_path, source_file), orient="records")
     elif os.path.isfile(output_path) and output_path.endswith(".json"):
-        df.to_json(output_path, orient='records')
+        df.to_json(output_path, orient="records")
+
 
 def map_labels(df: pd.DataFrame, label_col: str, label_map: Dict) -> pd.DataFrame:
     """[summary]
@@ -212,7 +236,9 @@ def map_labels(df: pd.DataFrame, label_col: str, label_map: Dict) -> pd.DataFram
     return df
 
 
-def resample_positives(df: pd.DataFrame, resample_rate: int, label_col: str, pos_label_val: Any, reshuffle=True) -> pd.DataFrame:
+def resample_positives(
+    df: pd.DataFrame, resample_rate: int, label_col: str, pos_label_val: Any, reshuffle=True
+) -> pd.DataFrame:
     """Given a dataframe, and logic identifying the positive label column, generate multiple copies of rows.
     Generally this is used on the training set with a sparse positive
 
@@ -222,26 +248,26 @@ def resample_positives(df: pd.DataFrame, resample_rate: int, label_col: str, pos
         actually make copies, because using the value 1 would not actually do anything.
         label_col (str): Will copy rows that match logic for this column name
         pos_label_val (Any): Will copy rows that match logic for the label_col column name to equal this label value.
-        reshuffle (bool, optional): Reshuffle the dataframe rows when done. Defaults to True. 
+        reshuffle (bool, optional): Reshuffle the dataframe rows when done. Defaults to True.
     Returns:
         pd.DataFrame: Dataframes with added rows.
-    
+
     Raises:
         ValueError: resample_rate is not a positive integer
     """
     if not isinstance(resample_rate, int) or resample_rate < 1:
         raise ValueError("Resample rate for positive rows must be a positive integer.")
     elif resample_rate > 1:
-        df_to_copy = df[df[label_col] == pos_label_val] 
+        df_to_copy = df[df[label_col] == pos_label_val]
         df = df.append([df_to_copy] * (resample_rate - 1), ignore_index=True)
     if reshuffle:
         df = df.sample(frac=1).reset_index(drop=True)
     return df
 
-def resample_multilabel_positives(df: pd.DataFrame,
-    resample_rate_dict: Dict,
-    pos_label_val: Any="1",
-    reshuffle=True) -> pd.DataFrame:
+
+def resample_multilabel_positives(
+    df: pd.DataFrame, resample_rate_dict: Dict, pos_label_val: Any = "1", reshuffle=True
+) -> pd.DataFrame:
     """Given a dataframe, and logic identifying positive label columns and their positive label values, generate multiple copies of rows.
     Generally this is used on the training set with one or more sparse positives.
 
@@ -251,8 +277,8 @@ def resample_multilabel_positives(df: pd.DataFrame,
     Also note that copies will be made for each label. So if a sample has several positive labels, a separate copy
     will be made for each of the label iteration values. For example:
 
-    {'A': 0, 'B': 1, 'C': 1, 'D': 1} might be a sample, 
-    
+    {'A': 0, 'B': 1, 'C': 1, 'D': 1} might be a sample,
+
     and if you had a resample rate dict of: {
         'A': 4,
         'B': 4,
@@ -267,29 +293,37 @@ def resample_multilabel_positives(df: pd.DataFrame,
         resample_rate_dict (Dict): A dictionary with keys equal to the label columns and values telling us the rate of positives to use for that key.
         Note that this must be at least 2 to actually make copies, because using the value 1 would not actually do anything.
         pos_label_val (Any, optional): Will copies rows that match logic for each label_cols column name to equal this label value. Defaults to "1".
-        reshuffle (bool, optional): Reshuffle the dataframe rows when done. Defaults to True. 
+        reshuffle (bool, optional): Reshuffle the dataframe rows when done. Defaults to True.
 
     Returns:
         pd.DataFrame: Dataframes with added rows.
-    
+
     Raises:
         ValueError: resample_rate has a value that is not a positive integer
         ValueError: resample_rate has a key that is not a column in the dataframe
     """
     dfs_to_add = []
-    for k,v in resample_rate_dict.items():
+    for k, v in resample_rate_dict.items():
         if not isinstance(v, int) or v < 1:
-            raise ValueError("All resample rates in resample_rate_dict must be positive integers. Value is {} for label {}".format(v,k))
+            raise ValueError(
+                "All resample rates in resample_rate_dict must be positive integers. Value is {} for label {}".format(
+                    v, k
+                )
+            )
         if k not in list(df.columns):
-            raise ValueError("Key {} is in resample_rate_dict but not in dataframe column list".format(k))
+            raise ValueError(
+                "Key {} is in resample_rate_dict but not in dataframe column list".format(k)
+            )
         if v > 1:
             df_to_copy = df[df[k] == pos_label_val]
-            for copy_index in range(v - 1): #if a resample rate is 2, this adds 1 copy, hence the subtraction
+            for copy_index in range(
+                v - 1
+            ):  # if a resample rate is 2, this adds 1 copy, hence the subtraction
                 dfs_to_add.append(df_to_copy)
-    
+
     for df_to_add in dfs_to_add:
         df = df.append(df_to_add, ignore_index=True)
-        
+
     if reshuffle:
         df = df.sample(frac=1).reset_index(drop=True)
     return df

--- a/sheepy/common/logger.py
+++ b/sheepy/common/logger.py
@@ -7,6 +7,6 @@ def get_std_out_logger(log_level=logging.INFO):
     handler = RichHandler(rich_tracebacks=True, log_time_format="%Y-%m-%d %H:%M:%S")
     handler.setLevel(log_level)
     handler.setFormatter(logging.Formatter("%(message)s"))
-    logger = logging.Logger('stdout_logger')
+    logger = logging.Logger("stdout_logger")
     logger.addHandler(handler)
     return logger

--- a/sheepy/common/s3_ops.py
+++ b/sheepy/common/s3_ops.py
@@ -1,5 +1,6 @@
 import requests
 
+
 def download_resource(key: str, output_path: str) -> str:
     """[summary]
 
@@ -10,12 +11,11 @@ def download_resource(key: str, output_path: str) -> str:
     Raises:
         botocore.exceptions.ClientError - The file does not exist at the specified s3 path
     """
-    url = 'https://robmsylvester.s3.us-west-1.amazonaws.com/{}'.format(key)
-    headers = {'Host': 'robmsylvester.s3.us-west-1.amazonaws.com'}
+    url = "https://robmsylvester.s3.us-west-1.amazonaws.com/{}".format(key)
+    headers = {"Host": "robmsylvester.s3.us-west-1.amazonaws.com"}
     with requests.get(url, headers=headers, stream=True) as r:
         r.raise_for_status()
-        with open(output_path, 'wb') as f:
-            for chunk in r.iter_content(chunk_size=8192): 
+        with open(output_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)
         return output_path
-

--- a/sheepy/data_modules/base_csv_data_module.py
+++ b/sheepy/data_modules/base_csv_data_module.py
@@ -189,7 +189,7 @@ class BaseCSVDataModule(BaseDataModule):
         Returns:
             [type]: [description]
         """
-        if stage == "fit" or stage == None:
+        if stage == "fit" or stage is None:
             if all_dataframes is None:
                 train_dataset, _, _ = split_dataframes(
                     train_dataframes,

--- a/sheepy/data_modules/base_csv_data_module.py
+++ b/sheepy/data_modules/base_csv_data_module.py
@@ -24,11 +24,12 @@ class BaseCSVDataModule(BaseDataModule):
         self.label_encoder = None
         self.train_class_sizes = None
         self._validate_data_dir_args()
-        self.args.x_cols = [] # Additional columns we care about, which for now is none.
+        self.args.x_cols = []  # Additional columns we care about, which for now is none.
 
         if self.text_col is None:
             raise ValueError(
-                "The base CSV data module requires a text column passed in the config file hparams with the key 'text'")
+                "The base CSV data module requires a text column passed in the config file hparams with the key 'text'"
+            )
 
     def _validate_data_dir_args(self):
         """Validates that either a data_dir arg has been passed, or alternatively separate arguments have been passed
@@ -39,18 +40,38 @@ class BaseCSVDataModule(BaseDataModule):
         """
         if self.evaluate:
             return
-        if hasattr(self.args, 'data_dir'):
+        if hasattr(self.args, "data_dir"):
             if not os.path.exists(self.args.data_dir):
                 self.logger.info("Creating new data directory at {}".format(self.args.data_dir))
                 os.makedirs(self.args.data_dir)
         else:
-            if not hasattr(self.args, 'train_data_dir') or not os.path.exists(self.args.train_data_dir):
-                raise ValueError("The passed directory for train_data_dir does not exist: {}".format(self.args.train_data_dir))
-            if not hasattr(self.args, 'val_data_dir') or not os.path.exists(self.args.val_data_dir):
-                raise ValueError("The passed directory for val_data_dir does not exist: {}".format(self.args.val_data_dir))
-            if not hasattr(self.args, 'test_data_dir') or not os.path.exists(self.args.test_data_dir):
-                raise ValueError("The passed directory for test_data_dir does not exist: {}".format(self.args.test_data_dir))
-            self.logger.info("Using separate filesystem data locations for train/val/test.\n\ttrain:{}\n\tval:{}\n\ttest:{}".format(self.args.train_data_dir, self.args.val_data_dir, self.args.test_data_dir))
+            if not hasattr(self.args, "train_data_dir") or not os.path.exists(
+                self.args.train_data_dir
+            ):
+                raise ValueError(
+                    "The passed directory for train_data_dir does not exist: {}".format(
+                        self.args.train_data_dir
+                    )
+                )
+            if not hasattr(self.args, "val_data_dir") or not os.path.exists(self.args.val_data_dir):
+                raise ValueError(
+                    "The passed directory for val_data_dir does not exist: {}".format(
+                        self.args.val_data_dir
+                    )
+                )
+            if not hasattr(self.args, "test_data_dir") or not os.path.exists(
+                self.args.test_data_dir
+            ):
+                raise ValueError(
+                    "The passed directory for test_data_dir does not exist: {}".format(
+                        self.args.test_data_dir
+                    )
+                )
+            self.logger.info(
+                "Using separate filesystem data locations for train/val/test.\n\ttrain:{}\n\tval:{}\n\ttest:{}".format(
+                    self.args.train_data_dir, self.args.val_data_dir, self.args.test_data_dir
+                )
+            )
 
     def _verify_module(self):
         """
@@ -70,22 +91,18 @@ class BaseCSVDataModule(BaseDataModule):
         """
         if out_path is None:
             out_path = os.path.join(self.args.output_dir, "data.module")
-        module_dict = {
-            'class_sizes': self.train_class_sizes,
-            'label_encoder': self.label_encoder
-        }
-        with open(out_path, 'wb') as fp:
+        module_dict = {"class_sizes": self.train_class_sizes, "label_encoder": self.label_encoder}
+        with open(out_path, "wb") as fp:
             pickle.dump(module_dict, fp)
 
     def load_data_module(self, in_path: str = None):
         if in_path is None:
             in_path = os.path.join(self.args.output_dir, "data.module")
-        with open(in_path, 'rb') as fp:
+        with open(in_path, "rb") as fp:
             module_dict = pickle.load(fp)
-            self.train_class_sizes = module_dict['class_sizes']
-            self.label_encoder = module_dict['label_encoder']
-        assert (self.label_encoder.vocab_size ==
-                self.args.hparams["num_labels"])
+            self.train_class_sizes = module_dict["class_sizes"]
+            self.label_encoder = module_dict["label_encoder"]
+        assert self.label_encoder.vocab_size == self.args.hparams["num_labels"]
 
     def _read_csv_directory(self, csv_path: str) -> List[pd.DataFrame]:
         """Given a directory of csv files, or a single csv file, return a list of pandas dataframes containing
@@ -109,12 +126,16 @@ class BaseCSVDataModule(BaseDataModule):
         for csv_file in csvs:
             fpath = csv_file if csv_file.endswith(".csv") else os.path.join(csv_path, csv_file)
             df = read_csv_text_classifier(
-                fpath, evaluate=self.evaluate, label_cols=self.label_col, text_col=self.text_col,
-                additional_cols=self.args.x_cols)
+                fpath,
+                evaluate=self.evaluate,
+                label_cols=self.label_col,
+                text_col=self.text_col,
+                additional_cols=self.args.x_cols,
+            )
             out_dfs.append(df)
         return out_dfs
 
-    def _resample_positive_rows(self, df: pd.DataFrame, positive_label: Any="1") -> pd.DataFrame:
+    def _resample_positive_rows(self, df: pd.DataFrame, positive_label: Any = "1") -> pd.DataFrame:
         """Calls the df_ops resample function for a given dataframe, subject to the parameter arguments
         provided to the experiment. Assumes that the sparse label is the positive label. If this is not
         the behavior you want, then you'll need to modify this. Ignores calling the function if
@@ -133,25 +154,29 @@ class BaseCSVDataModule(BaseDataModule):
         Returns:
             pd.DataFrame: Dataframe with resamples rows added
         """
-        resample_rate = self.args.hparams.get('positive_resample_rate', 1)
+        resample_rate = self.args.hparams.get("positive_resample_rate", 1)
 
-        if isinstance(self.label_col, str): #single label
+        if isinstance(self.label_col, str):  # single label
             label_dict = df[self.label_col].value_counts().to_dict()
             if positive_label is None:
                 positive_label = min(label_dict, key=label_dict.get)
                 self.logger.info("Inferred positive label is {}".format(positive_label))
             if resample_rate > 1:
                 self.logger.info("Resampling positives...")
-                return resample_positives(df,
-                    resample_rate,
-                    self.label_col,
-                    positive_label)
+                return resample_positives(df, resample_rate, self.label_col, positive_label)
             else:
                 return df
         else:
             return df
 
-    def split_dataframes(self, all_dataframes: List[pd.DataFrame]=None, train_dataframes: List[pd.DataFrame]=None, val_dataframes: List[pd.DataFrame]=None, test_dataframes: List[pd.DataFrame]=None, stage: str=None):
+    def split_dataframes(
+        self,
+        all_dataframes: List[pd.DataFrame] = None,
+        train_dataframes: List[pd.DataFrame] = None,
+        val_dataframes: List[pd.DataFrame] = None,
+        test_dataframes: List[pd.DataFrame] = None,
+        stage: str = None,
+    ):
         """[summary]
 
         Args:
@@ -166,31 +191,66 @@ class BaseCSVDataModule(BaseDataModule):
         """
         if stage == "fit" or stage == None:
             if all_dataframes is None:
-                train_dataset, _, _ = split_dataframes(train_dataframes, train_ratio=1., validation_ratio=0., test_ratio=0., shuffle=True)
-                _, val_dataset, _ = split_dataframes(val_dataframes, train_ratio=0., validation_ratio=1., test_ratio=0., shuffle=True)
-                _, _, test_dataset = split_dataframes(test_dataframes, train_ratio=0., validation_ratio=0., test_ratio=1., shuffle=True)
+                train_dataset, _, _ = split_dataframes(
+                    train_dataframes,
+                    train_ratio=1.0,
+                    validation_ratio=0.0,
+                    test_ratio=0.0,
+                    shuffle=True,
+                )
+                _, val_dataset, _ = split_dataframes(
+                    val_dataframes,
+                    train_ratio=0.0,
+                    validation_ratio=1.0,
+                    test_ratio=0.0,
+                    shuffle=True,
+                )
+                _, _, test_dataset = split_dataframes(
+                    test_dataframes,
+                    train_ratio=0.0,
+                    validation_ratio=0.0,
+                    test_ratio=1.0,
+                    shuffle=True,
+                )
             else:
                 train_dataset, val_dataset, test_dataset = split_dataframes(
-                    all_dataframes, train_ratio=self.args.hparams['train_ratio'],
-                    validation_ratio=self.args.hparams['validation_ratio'], test_ratio=None, shuffle=True)
+                    all_dataframes,
+                    train_ratio=self.args.hparams["train_ratio"],
+                    validation_ratio=self.args.hparams["validation_ratio"],
+                    test_ratio=None,
+                    shuffle=True,
+                )
 
             train_dataset = self._resample_positive_rows(train_dataset)
-            if 'label_map' in self.args.hparams and isinstance(self.args.hparams['label_map'], dict):
-                self.logger.info("Using label map {}".format(self.args.hparams['label_map']))
-                train_dataset = map_labels(train_dataset, self.label_col, self.args.hparams['label_map'])
-                val_dataset = map_labels(val_dataset, self.label_col, self.args.hparams['label_map'])
-                test_dataset = map_labels(test_dataset, self.label_col, self.args.hparams['label_map'])
+            if "label_map" in self.args.hparams and isinstance(
+                self.args.hparams["label_map"], dict
+            ):
+                self.logger.info("Using label map {}".format(self.args.hparams["label_map"]))
+                train_dataset = map_labels(
+                    train_dataset, self.label_col, self.args.hparams["label_map"]
+                )
+                val_dataset = map_labels(
+                    val_dataset, self.label_col, self.args.hparams["label_map"]
+                )
+                test_dataset = map_labels(
+                    test_dataset, self.label_col, self.args.hparams["label_map"]
+                )
 
-            self.logger.info("Dataset split complete. (Total) Dataset Shapes:\n\tTrain: {}\nV\talidation: {}\n\tTest: {}".format(
-                train_dataset.shape, val_dataset.shape, test_dataset.shape))
+            self.logger.info(
+                "Dataset split complete. (Total) Dataset Shapes:\n\tTrain: {}\nV\talidation: {}\n\tTest: {}".format(
+                    train_dataset.shape, val_dataset.shape, test_dataset.shape
+                )
+            )
 
             return train_dataset, val_dataset, test_dataset
-        else: #evaluating
-            test_dataset = pd.concat(all_dataframes if all_dataframes is not None else test_dataframes)
-            test_dataset[self.sample_id_col] = range(
-                len(test_dataset))
-            self.logger.info("In evaluation mode. Dataset Shapes:\n\tTest: {}".format(
-                test_dataset.shape))
+        else:  # evaluating
+            test_dataset = pd.concat(
+                all_dataframes if all_dataframes is not None else test_dataframes
+            )
+            test_dataset[self.sample_id_col] = range(len(test_dataset))
+            self.logger.info(
+                "In evaluation mode. Dataset Shapes:\n\tTest: {}".format(test_dataset.shape)
+            )
             return None, None, test_dataset
 
     def _set_class_sizes(self):
@@ -199,14 +259,30 @@ class BaseCSVDataModule(BaseDataModule):
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
-        parser.add_argument("--data_dir", type=str, required=False,
-                            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file")
-        parser.add_argument("--train_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the training csvs, or alternatively a single train csv file")
-        parser.add_argument("--val_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the validation csvs, or alternatively a single validation csv file")
-        parser.add_argument("--test_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the test csvs, or alternatively a single test csv file")
+        """Return the argument parser with necessary args for this class appended to it"""
+        parser.add_argument(
+            "--data_dir",
+            type=str,
+            required=False,
+            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file",
+        )
+        parser.add_argument(
+            "--train_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the training csvs, or alternatively a single train csv file",
+        )
+        parser.add_argument(
+            "--val_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the validation csvs, or alternatively a single validation csv file",
+        )
+        parser.add_argument(
+            "--test_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the test csvs, or alternatively a single test csv file",
+        )
 
         return parser

--- a/sheepy/data_modules/base_data_module.py
+++ b/sheepy/data_modules/base_data_module.py
@@ -15,22 +15,26 @@ from sheepy.nlp.tokenizer import Tokenizer
 
 
 class BaseDataModule(LightningDataModule):
-
     def __init__(self, args: argparse.Namespace):
         super().__init__()
         self.logger = get_std_out_logger()
         self.args = args
         self._set_tune_params()
-        self.sample_id_col = 'sample_id'
+        self.sample_id_col = "sample_id"
         self.evaluate = self.args.evaluate  # readability
         self.label_col = self.args.hparams["label"]  # readability
         self.text_col = self.args.hparams["text"]  # readability
 
-        self._train_dataset, self._val_dataset, self._test_dataset, self._predict_dataset = None, None, None, None
+        self._train_dataset, self._val_dataset, self._test_dataset, self._predict_dataset = (
+            None,
+            None,
+            None,
+            None,
+        )
         if not os.path.exists(self.args.output_dir):
             os.makedirs(self.args.output_dir)
 
-        self.tokenizer = Tokenizer(self.args.hparams['encoder_model'])
+        self.tokenizer = Tokenizer(self.args.hparams["encoder_model"])
 
     def _set_tune_params(self):
         # TODO - we may want to support iterating through other config than hparams, such as the encoder_model
@@ -39,7 +43,9 @@ class BaseDataModule(LightningDataModule):
             for k, v in wandb.config.items():
                 if k in self.args.hparams:
                     self.args.hparams[k] = v
-                    self.logger.debug("Setting data module hyperparameter {} to sweep value {}".format(k, v))
+                    self.logger.debug(
+                        "Setting data module hyperparameter {} to sweep value {}".format(k, v)
+                    )
 
     def prepare_data(self):
         raise NotImplementedError("This must be implemented by child class.")
@@ -78,16 +84,19 @@ class BaseDataModule(LightningDataModule):
         """
         if self.text_col is None:
             raise NotImplementedError(
-                "To use the default collate function you need a text column.\nAlternatively, write one for the x_cols to prepare your data")
+                "To use the default collate function you need a text column.\nAlternatively, write one for the x_cols to prepare your data"
+            )
 
         # TODO - turn this into always using windowed text collate function
-        return single_text_collate_function(sample,
-                                            self.text_col,
-                                            self.label_col,
-                                            self.sample_id_col,
-                                            self.tokenizer,
-                                            self.label_encoder,
-                                            evaluate=self.evaluate)
+        return single_text_collate_function(
+            sample,
+            self.text_col,
+            self.label_col,
+            self.sample_id_col,
+            self.tokenizer,
+            self.label_encoder,
+            evaluate=self.evaluate,
+        )
 
     def _write_predictions(self, outputs: List[dict]) -> None:
         all_columns = self.label_encoder.vocab
@@ -99,16 +108,26 @@ class BaseDataModule(LightningDataModule):
             sample_ids = pd.Series(output["sample_id_keys"].cpu().squeeze()).astype("int")
             prediction_softmax = torch.nn.Softmax(dim=1)(prediction_logits)
             batch_prediction_df = pd.DataFrame(prediction_softmax).astype("float")
-            batch_prediction_df = batch_prediction_df.rename(columns={label_idx: label for label_idx, label in enumerate(self.label_encoder.vocab)})
+            batch_prediction_df = batch_prediction_df.rename(
+                columns={
+                    label_idx: label for label_idx, label in enumerate(self.label_encoder.vocab)
+                }
+            )
             batch_prediction_df[self.sample_id_col] = sample_ids
-            all_batch_predictions_df = all_batch_predictions_df.append(batch_prediction_df, ignore_index=True)
+            all_batch_predictions_df = all_batch_predictions_df.append(
+                batch_prediction_df, ignore_index=True
+            )
 
         all_batch_predictions_df = all_batch_predictions_df.reset_index(drop=True)
         cols = all_batch_predictions_df.columns.tolist()
         cols = cols[-1:] + cols[:-1]
         all_batch_predictions_df = all_batch_predictions_df[cols]
 
-        self.logger.info("Writing CSV file with {} predictions to {}".format(all_batch_predictions_df.shape[0], self.args.output_prediction_path))
+        self.logger.info(
+            "Writing CSV file with {} predictions to {}".format(
+                all_batch_predictions_df.shape[0], self.args.output_prediction_path
+            )
+        )
         all_batch_predictions_df.to_csv(self.args.output_prediction_path)
 
     def _verify_dataset_record_type(self, dataset: Union[pd.DataFrame, List[Dict]]) -> List[Dict]:
@@ -139,7 +158,11 @@ class BaseDataModule(LightningDataModule):
         with open(filepath, "r") as f:
             for idx, line in enumerate(f):
                 line = line.rstrip()
-                prepared_input = {self.text_col: line, self.label_col: None, self.sample_id_col: idx}
+                prepared_input = {
+                    self.text_col: line,
+                    self.label_col: None,
+                    self.sample_id_col: idx,
+                }
                 prepared_inputs.append(prepared_input)
         return prepared_inputs
 
@@ -149,58 +172,60 @@ class BaseDataModule(LightningDataModule):
         return [prepared_input]
 
     def train_dataloader(self) -> DataLoader:
-        """ Function that loads the train set. """
+        """Function that loads the train set."""
         self._train_dataset = self._verify_dataset_record_type(self._train_dataset)
         return DataLoader(
             dataset=self._train_dataset,
             sampler=RandomSampler(self._train_dataset),
-            batch_size=self.args.hparams['batch_size'],
+            batch_size=self.args.hparams["batch_size"],
             collate_fn=self.prepare_sample,
-            num_workers=self.args.hparams['loader_workers'],
+            num_workers=self.args.hparams["loader_workers"],
         )
 
     def val_dataloader(self) -> DataLoader:
-        """ Function that loads the validation set. """
+        """Function that loads the validation set."""
         self._val_dataset = self._verify_dataset_record_type(self._val_dataset)
         return DataLoader(
             dataset=self._val_dataset,
-            batch_size=self.args.hparams['batch_size'],
+            batch_size=self.args.hparams["batch_size"],
             collate_fn=self.prepare_sample,
-            num_workers=self.args.hparams['loader_workers'],
+            num_workers=self.args.hparams["loader_workers"],
         )
 
     def test_dataloader(self) -> DataLoader:
-        """ Function that loads the test set. """
+        """Function that loads the test set."""
         self._test_dataset = self._verify_dataset_record_type(self._test_dataset)
         return DataLoader(
             dataset=self._test_dataset,
-            batch_size=self.args.hparams['batch_size'],
+            batch_size=self.args.hparams["batch_size"],
             collate_fn=self.prepare_sample,
-            num_workers=self.args.hparams['loader_workers'],
+            num_workers=self.args.hparams["loader_workers"],
         )
 
     def predict_batch_dataloader(self) -> DataLoader:
-        """ Function that loads batch prediction by processing lines in a text file"""
+        """Function that loads batch prediction by processing lines in a text file"""
         self._predict_dataset = self._load_text_from_text_file(self.args.evaluate_batch_file)
         return DataLoader(
             dataset=self._predict_dataset,
-            batch_size=self.args.hparams['batch_size'],
+            batch_size=self.args.hparams["batch_size"],
             collate_fn=self.prepare_sample,
-            num_workers=self.args.hparams['loader_workers'],
+            num_workers=self.args.hparams["loader_workers"],
         )
 
     def predict_live_dataloader(self) -> DataLoader:
-        """ Function that loads the batch prediction set by processing a single piece of text input to the shell """
+        """Function that loads the batch prediction set by processing a single piece of text input to the shell"""
         self._predict_dataset = self._load_text_from_raw_input()
         return DataLoader(
             dataset=self._predict_dataset,
-            batch_size=self.args.hparams['batch_size'],
+            batch_size=self.args.hparams["batch_size"],
             collate_fn=self.prepare_sample,
-            num_workers=self.args.hparams['loader_workers'],
+            num_workers=self.args.hparams["loader_workers"],
         )
 
     def _build_label_encoder(self):
-        self.label_encoder = LabelEncoder.initializeFromDataframe(self._train_dataset, self.args.hparams["label"])
+        self.label_encoder = LabelEncoder.initializeFromDataframe(
+            self._train_dataset, self.args.hparams["label"]
+        )
         self.logger.info("Label Encoder Vocab: {}".format(self.label_encoder.vocab))
 
     # TODO - probably move to csv, generalize one
@@ -208,7 +233,7 @@ class BaseDataModule(LightningDataModule):
         self.train_class_sizes = None  # Write this
         raise NotImplementedError("This must be implemented by child class.")
 
-    @ classmethod
+    @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
+        """Return the argument parser with necessary args for this class appended to it"""
         return parser

--- a/sheepy/data_modules/multi_label_base_data_module.py
+++ b/sheepy/data_modules/multi_label_base_data_module.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import List
 
 from sheepy.data_modules.base_data_module import BaseDataModule
 

--- a/sheepy/data_modules/multi_label_base_data_module.py
+++ b/sheepy/data_modules/multi_label_base_data_module.py
@@ -27,16 +27,23 @@ class MultiLabelBaseDataModule(BaseDataModule):
 
     def _verify_multilabel(self):
         assert isinstance(
-            self.args.hparams["label"], list), "hyperparameter of labels must be a list for the multi label module to be used"
-        assert len(
-            self.args.hparams["label"]) > 1, "there must be more than one label in the list for the multi label module to be used"
-        assert self.args.hparams["num_labels"] == len(self.args.hparams["label"]), "config sees {} labels but num_labels set to {}".format(
-            len(self.args.hparams["label"]), self.args.hparams["num_labels"])
-
+            self.args.hparams["label"], list
+        ), "hyperparameter of labels must be a list for the multi label module to be used"
+        assert (
+            len(self.args.hparams["label"]) > 1
+        ), "there must be more than one label in the list for the multi label module to be used"
+        assert self.args.hparams["num_labels"] == len(
+            self.args.hparams["label"]
+        ), "config sees {} labels but num_labels set to {}".format(
+            len(self.args.hparams["label"]), self.args.hparams["num_labels"]
+        )
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
-        parser.add_argument("--disable_weight_scale", action="store_true",
-                            help="Disables automatically scaling class weights from training set")
+        """Return the argument parser with necessary args for this class appended to it"""
+        parser.add_argument(
+            "--disable_weight_scale",
+            action="store_true",
+            help="Disables automatically scaling class weights from training set",
+        )
         return parser

--- a/sheepy/data_modules/multi_label_csv_data_module.py
+++ b/sheepy/data_modules/multi_label_csv_data_module.py
@@ -20,18 +20,24 @@ class MultiLabelCSVDataModule(BaseCSVDataModule):
         # Additional columns we care about, which for now is none.
         if self.text_col is None:
             raise ValueError(
-                "The base CSV data module requires a text column passed in the config file hparams with the key 'text'")
+                "The base CSV data module requires a text column passed in the config file hparams with the key 'text'"
+            )
         self._verify_multilabel()
 
     def _verify_multilabel(self):
         assert isinstance(
-            self.args.hparams["label"], list), "hyperparameter of labels must be a list for the multi label module to be used"
-        assert len(
-            self.args.hparams["label"]) > 1, "there must be more than one label in the list for the multi label module to be used"
-        assert self.args.hparams["num_labels"] == len(self.args.hparams["label"]), "config sees {} labels but num_labels set to {}".format(
-            len(self.args.hparams["label"]), self.args.hparams["num_labels"])
+            self.args.hparams["label"], list
+        ), "hyperparameter of labels must be a list for the multi label module to be used"
+        assert (
+            len(self.args.hparams["label"]) > 1
+        ), "there must be more than one label in the list for the multi label module to be used"
+        assert self.args.hparams["num_labels"] == len(
+            self.args.hparams["label"]
+        ), "config sees {} labels but num_labels set to {}".format(
+            len(self.args.hparams["label"]), self.args.hparams["num_labels"]
+        )
 
-    def _resample_positive_rows(self, df: pd.DataFrame, positive_label: Any="1") -> pd.DataFrame:
+    def _resample_positive_rows(self, df: pd.DataFrame, positive_label: Any = "1") -> pd.DataFrame:
         """Calls the df_ops resample function for a given dataframe, subject to the parameter arguments
         provided to the experiment. Assumes that the sparse label is the positive label. If this is not
         the behavior you want, then you'll need to modify this. Ignores calling the function if
@@ -50,14 +56,14 @@ class MultiLabelCSVDataModule(BaseCSVDataModule):
         Returns:
             pd.DataFrame: Dataframe with resamples rows added
         """
-        resample_rate = self.args.hparams.get('positive_resample_rate', 1)
+        resample_rate = self.args.hparams.get("positive_resample_rate", 1)
         if isinstance(resample_rate, dict):
             self.logger.info("Resampling multilabel positives...")
             return resample_multilabel_positives(df, resample_rate, positive_label)
         elif isinstance(resample_rate, int):
             resample_rate = {k: resample_rate for k in self.label_col}
 
-            all_ones= all(v == 1 for v in resample_rate.values())
+            all_ones = all(v == 1 for v in resample_rate.values())
             if all_ones:
                 return df
             else:
@@ -106,25 +112,24 @@ class MultiLabelCSVDataModule(BaseCSVDataModule):
         if out_path is None:
             out_path = os.path.join(self.args.output_dir, "data.module")
         module_dict = {
-            'class_sizes': self.train_class_sizes,
-            'label_encoder': self.label_encoder,
-            'pos_weights': self.pos_weights,
+            "class_sizes": self.train_class_sizes,
+            "label_encoder": self.label_encoder,
+            "pos_weights": self.pos_weights,
         }
-        with open(out_path, 'wb') as fp:
+        with open(out_path, "wb") as fp:
             pickle.dump(module_dict, fp)
 
     def load_data_module(self, in_path: str = None):
         if in_path is None:
             in_path = os.path.join(self.args.output_dir, "data.module")
-        with open(in_path, 'rb') as fp:
+        with open(in_path, "rb") as fp:
             module_dict = pickle.load(fp)
-            self.train_class_sizes = module_dict['class_sizes']
-            self.label_encoder = module_dict['label_encoder']
-            self.pos_weights = module_dict['pos_weights']
-        assert (self.label_encoder.vocab_size ==
-                self.args.hparams["num_labels"])
+            self.train_class_sizes = module_dict["class_sizes"]
+            self.label_encoder = module_dict["label_encoder"]
+            self.pos_weights = module_dict["pos_weights"]
+        assert self.label_encoder.vocab_size == self.args.hparams["num_labels"]
 
-    #TODO - this one is probably good
+    # TODO - this one is probably good
     def _set_class_sizes(self, positive_label="1", negative_label="0"):
         """
         Searches through the labels in the dataset and counts the number of positives/negatives for each.
@@ -135,33 +140,52 @@ class MultiLabelCSVDataModule(BaseCSVDataModule):
         self.pos_weights = {}
         for col in self.label_col:
             if not self._train_dataset[col].nunique() == 2:
-                raise ValueError("Saw {} unique values in label {}. Each individual label should be binary".format(
-                    self._train_dataset[col].nunique(), col))
-            pos_size = self._train_dataset[self._train_dataset[col]
-                                           == positive_label].shape[0]
-            neg_size = self._train_dataset[self._train_dataset[col]
-                                           == negative_label].shape[0]
+                raise ValueError(
+                    "Saw {} unique values in label {}. Each individual label should be binary".format(
+                        self._train_dataset[col].nunique(), col
+                    )
+                )
+            pos_size = self._train_dataset[self._train_dataset[col] == positive_label].shape[0]
+            neg_size = self._train_dataset[self._train_dataset[col] == negative_label].shape[0]
             self.train_class_sizes[col] = pos_size
             self.pos_weights[col] = float(neg_size) / pos_size
-        self.logger.info("\nPositive Label Count (Train):\n{}".format(
-            self.train_class_sizes))
-        self.logger.info("\nPositive Label Weights (Train): (Ratio of Neg/Pos)\n{}".format(
-            self.pos_weights))
+        self.logger.info("\nPositive Label Count (Train):\n{}".format(self.train_class_sizes))
+        self.logger.info(
+            "\nPositive Label Weights (Train): (Ratio of Neg/Pos)\n{}".format(self.pos_weights)
+        )
 
     def _build_label_encoder(self):
-        self.label_encoder = LabelEncoder.initializeFromMultilabelDataframe(self._train_dataset, self.args.hparams["label"])
+        self.label_encoder = LabelEncoder.initializeFromMultilabelDataframe(
+            self._train_dataset, self.args.hparams["label"]
+        )
         self.logger.info("Label Encoder Vocab: {}".format(self.label_encoder.vocab))
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
-        parser.add_argument("--data_dir", type=str, required=False,
-                            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file")
-        parser.add_argument("--train_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the training csvs, or alternatively a single train csv file")
-        parser.add_argument("--val_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the validation csvs, or alternatively a single validation csv file")
-        parser.add_argument("--test_data_dir", type=str, required=False,
-                            help="If your data is split across folders, this is the path to the directory containing the test csvs, or alternatively a single test csv file")
+        """Return the argument parser with necessary args for this class appended to it"""
+        parser.add_argument(
+            "--data_dir",
+            type=str,
+            required=False,
+            help="If all of your data is in one folder, this is the path to that directory containing the csvs, or alternatively a single csv file",
+        )
+        parser.add_argument(
+            "--train_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the training csvs, or alternatively a single train csv file",
+        )
+        parser.add_argument(
+            "--val_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the validation csvs, or alternatively a single validation csv file",
+        )
+        parser.add_argument(
+            "--test_data_dir",
+            type=str,
+            required=False,
+            help="If your data is split across folders, this is the path to the directory containing the test csvs, or alternatively a single test csv file",
+        )
 
         return parser

--- a/sheepy/experiment/base_experiment.py
+++ b/sheepy/experiment/base_experiment.py
@@ -297,7 +297,8 @@ class Experiment:
 
             if args.pretrained_dir is None:
                 args.pretrained_dir = os.path.join(
-                    args.output_dir, args.project_name, "models", args.experiment_name)
+                    args.output_dir, args.project_name, "models", args.experiment_name
+                )
 
             args.output_dir = os.path.join(args.pretrained_dir, "eval")
 
@@ -312,7 +313,8 @@ class Experiment:
                 )
 
             args.output_dir = os.path.join(
-                args.output_dir, args.project_name, "models", args.experiment_name)
+                args.output_dir, args.project_name, "models", args.experiment_name
+            )
 
         if not os.path.exists(args.output_dir):
             os.makedirs(args.output_dir)
@@ -321,13 +323,21 @@ class Experiment:
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument pasrser with necessary args for this class appended to it """
-        parser.add_argument("--project_name", type=str, default="dummy_project",
-                            help="A custom project name. Will house all experiments under this project directory. First level under the output dir")
-        parser.add_argument("--experiment_name", type=str, default=None,
-                            help="A custom experiment name. Otherwise it will be be set to {16/32}bit_{time}_{version}, but give it a name/ Second level under the output dir")
-        parser.add_argument("--version", type=str, default="0",
-                            help="Version of model. Defaults to 0")
-        parser.add_argument("--verbose", action="store_true",
-                            help="Enable for debug-level logging")
+        """Return the argument pasrser with necessary args for this class appended to it"""
+        parser.add_argument(
+            "--project_name",
+            type=str,
+            default="dummy_project",
+            help="A custom project name. Will house all experiments under this project directory. First level under the output dir",
+        )
+        parser.add_argument(
+            "--experiment_name",
+            type=str,
+            default=None,
+            help="A custom experiment name. Otherwise it will be be set to {16/32}bit_{time}_{version}, but give it a name/ Second level under the output dir",
+        )
+        parser.add_argument(
+            "--version", type=str, default="0", help="Version of model. Defaults to 0"
+        )
+        parser.add_argument("--verbose", action="store_true", help="Enable for debug-level logging")
         return parser

--- a/sheepy/experiment/base_experiment.py
+++ b/sheepy/experiment/base_experiment.py
@@ -13,7 +13,8 @@ from sheepy.common.logger import get_std_out_logger
 
 # TODO - add restore from checkpoint
 
-class Experiment():
+
+class Experiment:
     def __init__(self, args: argparse.Namespace, logger=None, evaluation=False):
         self.evaluation = evaluation
         self.logger = logger if logger is not None else get_std_out_logger()
@@ -39,7 +40,12 @@ class Experiment():
             self.args.hparams = config["hparams"]
             self.args.metrics = config["metrics"]
 
-    def prepare_trainer(self, data_module_cls: pl.LightningDataModule, model_cls: pl.LightningModule, pretrained_experiment_folder: str = None):
+    def prepare_trainer(
+        self,
+        data_module_cls: pl.LightningDataModule,
+        model_cls: pl.LightningModule,
+        pretrained_experiment_folder: str = None,
+    ):
         """
         The prepare function is called on the experiment class to set up the two pytorch lightning abstractions used by the framework,
         namely, the data module, and the model module. According to other experiment args, various other things will get set up to track
@@ -70,7 +76,9 @@ class Experiment():
         self._prepare_logger()
 
     # TODO: merge this method with prepare_trainer()
-    def prepare_evaluator(self, data_module_cls: pl.LightningDataModule, model_cls: pl.LightningModule):
+    def prepare_evaluator(
+        self, data_module_cls: pl.LightningDataModule, model_cls: pl.LightningModule
+    ):
         """Runs through all the module loading and checks to get the model ready to run evaluation.
 
         Args:
@@ -83,8 +91,7 @@ class Experiment():
         """
         if self.args.pretrained_dir:
             load_from_checkpoint = True
-            self.logger.info("Loading model from {}".format(
-                self.args.pretrained_dir))
+            self.logger.info("Loading model from {}".format(self.args.pretrained_dir))
         else:
             load_from_checkpoint = False
 
@@ -105,19 +112,27 @@ class Experiment():
             self.data.label_encoder = model_data.label_encoder
             self.data.train_class_sizes = model_data.train_class_sizes
 
-            if hasattr(model_data, 'pos_weights'):
+            if hasattr(model_data, "pos_weights"):
                 self.data.pos_weights = model_data.pos_weights
 
             # Then the model from the checkpoint. Note that in pytl v1 the 'checkpoints' subdirectory was removed
-            checkpoints = [os.path.join(self.args.pretrained_dir, f) for f in os.listdir(
-                self.args.pretrained_dir) if f.endswith(".ckpt")]
+            checkpoints = [
+                os.path.join(self.args.pretrained_dir, f)
+                for f in os.listdir(self.args.pretrained_dir)
+                if f.endswith(".ckpt")
+            ]
             if len(checkpoints) != 1:
-                raise ValueError("Your model directory {} should have exactly one .ckpt file in it. Instead, there are {}".format(
-                    self.args.pretrained_dir, len(checkpoints)))
+                raise ValueError(
+                    "Your model directory {} should have exactly one .ckpt file in it. Instead, there are {}".format(
+                        self.args.pretrained_dir, len(checkpoints)
+                    )
+                )
 
             # TODO - double check this -1 behavior on overfit model
             self.checkpoint_path = checkpoints[0]
-            self.model = model_cls.load_from_checkpoint(self.checkpoint_path, args=model_args, data=self.data)
+            self.model = model_cls.load_from_checkpoint(
+                self.checkpoint_path, args=model_args, data=self.data
+            )
 
             self.model.live_eval_mode = self.args.evaluate_live
 
@@ -142,20 +157,33 @@ class Experiment():
 
     def _build_wandb_logger(self):
         """Helper function to dump weights and biases files into a model's directory"""
-        logger = WandbLogger(name=self.args.experiment_name,
-                             save_dir=self.args.output_dir,
-                             project=self.args.project_name,
-                             version=self.args.version)
+        logger = WandbLogger(
+            name=self.args.experiment_name,
+            save_dir=self.args.output_dir,
+            project=self.args.project_name,
+            version=self.args.version,
+        )
         self.wandb = logger
 
     def _prepare_logger(self):
         """Helper function that sets the verbosity of logging in weights and biases and pytorch"""
-        if self.args.validation['gradient_log_steps'] is not None and self.args.validation['param_log_steps'] is not None:
-            log_steps = min(self.args.validation['gradient_log_steps'], self.args.validation['param_log_steps'])
-        elif self.args.validation['gradient_log_steps'] is None and self.args.validation['param_log_steps'] is not None:
-            log_steps = self.args.validation['param_log_steps']
-        elif self.args.validation['gradient_log_steps'] is not None and self.args.validation['param_log_steps'] is None:
-            log_steps = self.args.validation['gradient_log_steps']
+        if (
+            self.args.validation["gradient_log_steps"] is not None
+            and self.args.validation["param_log_steps"] is not None
+        ):
+            log_steps = min(
+                self.args.validation["gradient_log_steps"], self.args.validation["param_log_steps"]
+            )
+        elif (
+            self.args.validation["gradient_log_steps"] is None
+            and self.args.validation["param_log_steps"] is not None
+        ):
+            log_steps = self.args.validation["param_log_steps"]
+        elif (
+            self.args.validation["gradient_log_steps"] is not None
+            and self.args.validation["param_log_steps"] is None
+        ):
+            log_steps = self.args.validation["gradient_log_steps"]
         else:
             log_steps = None
         # TODO - self.log_hyperparams and self.log_metrics should be called here too eventually
@@ -171,19 +199,23 @@ class Experiment():
         """
         self.checkpoint_callback = self._build_checkpoint_callback()
         self.lr_monitor_callback = LearningRateMonitor()
-        self.custom_callbacks = [self.checkpoint_callback, self.lr_monitor_callback, RichProgressBar()]
-        if self.args.hparams['early_stop_enabled']:
+        self.custom_callbacks = [
+            self.checkpoint_callback,
+            self.lr_monitor_callback,
+            RichProgressBar(),
+        ]
+        if self.args.hparams["early_stop_enabled"]:
             self.early_stop_callback = self._build_early_stop_callback()
             self.custom_callbacks.append(self.early_stop_callback)
 
     def _build_early_stop_callback(self):
         """Helper function to wrap around PyTL's early-stopping function, around validation loss only at this moment"""
         early_stop = EarlyStopping(
-            monitor=self.args.validation['metric'],
-            min_delta=0.,
+            monitor=self.args.validation["metric"],
+            min_delta=0.0,
             patience=3,
             verbose=False,
-            mode=self.args.validation['metric_goal']
+            mode=self.args.validation["metric_goal"],
         )
         return early_stop
 
@@ -193,8 +225,8 @@ class Experiment():
             dirpath=self.args.output_dir,
             save_top_k=1,
             verbose=True,
-            monitor=self.args.validation['metric'],
-            mode=self.args.validation['metric_goal'],
+            monitor=self.args.validation["metric"],
+            mode=self.args.validation["metric_goal"],
         )
         return checkpoint_callback
 
@@ -202,17 +234,17 @@ class Experiment():
         self.trainer = pl.Trainer(
             callbacks=self.custom_callbacks,
             logger=self.wandb,
-            gradient_clip_val=self.args.hparams['gradient_clip_val'],
+            gradient_clip_val=self.args.hparams["gradient_clip_val"],
             gpus=self.args.n_gpu,
             log_gpu_memory="all",
             deterministic=True,
-            check_val_every_n_epoch=self.args.validation['check_val_every_n_epoch'],
+            check_val_every_n_epoch=self.args.validation["check_val_every_n_epoch"],
             fast_dev_run=False,
-            accumulate_grad_batches=self.args.hparams['accumulate_grad_batches'],
-            max_epochs=self.args.hparams['num_epochs'],
-            val_check_interval=self.args.validation['val_check_interval'],
+            accumulate_grad_batches=self.args.hparams["accumulate_grad_batches"],
+            max_epochs=self.args.hparams["num_epochs"],
+            val_check_interval=self.args.validation["val_check_interval"],
             strategy="dp" if self.args.n_gpu >= 2 else None,
-            precision=self.args.precision
+            precision=self.args.precision,
         )
 
     def train(self):
@@ -248,20 +280,26 @@ class Experiment():
 
             if not args.evaluate_live:
                 if not args.evaluate_batch_file:
-                    raise ArgumentError("When running in batch evaluation mode, you must provide a text file to the evaluate_batch_file argument")
+                    raise ArgumentError(
+                        "When running in batch evaluation mode, you must provide a text file to the evaluate_batch_file argument"
+                    )
                 if not os.path.exists(args.evaluate_batch_file):
-                    raise ArgumentError("Cannot find evaluate_batch_file in file system located at {}".format(args.evaluate_batch_file))
+                    raise ArgumentError(
+                        "Cannot find evaluate_batch_file in file system located at {}".format(
+                            args.evaluate_batch_file
+                        )
+                    )
 
             if args.experiment_name is None or args.output_key is None:
                 raise ArgumentError(
-                    "You must pass a pretrained experiment name and the output column name or dict key as output_key.")
+                    "You must pass a pretrained experiment name and the output column name or dict key as output_key."
+                )
 
             if args.pretrained_dir is None:
                 args.pretrained_dir = os.path.join(
                     args.output_dir, args.project_name, "models", args.experiment_name)
 
-            args.output_dir = os.path.join(
-                args.pretrained_dir, 'eval')
+            args.output_dir = os.path.join(args.pretrained_dir, "eval")
 
             args.output_prediction_path = os.path.join(args.output_dir, "batch_predictions.csv")
 
@@ -270,7 +308,8 @@ class Experiment():
         else:
             if args.experiment_name is None:
                 args.experiment_name = "{}bit_{}_v{}".format(
-                    args.precision, args.time, args.version)
+                    args.precision, args.time, args.version
+                )
 
             args.output_dir = os.path.join(
                 args.output_dir, args.project_name, "models", args.experiment_name)

--- a/sheepy/experiment/sweep_experiment.py
+++ b/sheepy/experiment/sweep_experiment.py
@@ -12,11 +12,16 @@ from sheepy.experiment.base_experiment import Experiment
 
 
 class SweepExperiment(Experiment):
-    def __init__(self, args: Namespace, data_module_cls: pl.LightningDataModule, model_cls: pl.LightningModule):
+    def __init__(
+        self,
+        args: Namespace,
+        data_module_cls: pl.LightningDataModule,
+        model_cls: pl.LightningModule,
+    ):
         super().__init__(args)
         self.data_module_cls = data_module_cls
         self.model_cls = model_cls
-        set_start_method('spawn', force=True)  # multiprocessing necessity
+        set_start_method("spawn", force=True)  # multiprocessing necessity
         self.logger = None
 
     def _build_sweep_trainer(self):
@@ -26,18 +31,18 @@ class SweepExperiment(Experiment):
         return pl.Trainer(
             callbacks=self.custom_callbacks,
             logger=self.wandb,
-            gradient_clip_val=self.args.hparams['gradient_clip_val'],
+            gradient_clip_val=self.args.hparams["gradient_clip_val"],
             gpus=self.args.n_gpu,
             log_gpu_memory="all",
             deterministic=True,
-            check_val_every_n_epoch=self.args.validation['check_val_every_n_epoch'],
+            check_val_every_n_epoch=self.args.validation["check_val_every_n_epoch"],
             fast_dev_run=False,
-            accumulate_grad_batches=self.args.hparams['accumulate_grad_batches'],
-            max_epochs=self.args.hparams['num_epochs'],
-            val_check_interval=self.args.validation['val_check_interval'],
-            accelerator='dp',
-            amp_level='O1',
-            precision=self.args.precision
+            accumulate_grad_batches=self.args.hparams["accumulate_grad_batches"],
+            max_epochs=self.args.hparams["num_epochs"],
+            val_check_interval=self.args.validation["val_check_interval"],
+            accelerator="dp",
+            amp_level="O1",
+            precision=self.args.precision,
         )
 
     def sweep_iteration(self):
@@ -66,6 +71,5 @@ class SweepExperiment(Experiment):
         """
         Runs a sweep or hyperparameters that can be visualized in the browser.
         """
-        sweep_id = wandb.sweep(
-            self.args.sweep, project=self.args.experiment_name)
+        sweep_id = wandb.sweep(self.args.sweep, project=self.args.experiment_name)
         wandb.agent(sweep_id, function=self.sweep_iteration)

--- a/sheepy/models/__init__.py
+++ b/sheepy/models/__init__.py
@@ -3,7 +3,7 @@ from sheepy.models.multiclass_transformer_classifier import MulticlassTransforme
 from sheepy.models.multilabel_transformer_classifier import MultiLabelTransformerClassifier
 
 MODEL_MAPPING = {
-    'transformer_classifier': TransformerClassifier,
-    'multiclass_transformer_classifier': MulticlassTransformerClassifier,
-    'multilabel_transformer_classifier': MultiLabelTransformerClassifier
+    "transformer_classifier": TransformerClassifier,
+    "multiclass_transformer_classifier": MulticlassTransformerClassifier,
+    "multilabel_transformer_classifier": MultiLabelTransformerClassifier,
 }

--- a/sheepy/models/base_classifier.py
+++ b/sheepy/models/base_classifier.py
@@ -274,7 +274,7 @@ class BaseClassifier(pl.LightningModule):
         self.model.save_pretrained(save_path)
         self.data.tokenizer.tokenizer.save_pretrained(save_path)
 
-    #NOTE - PyTorch Lightning 1.5.1 still uses this on_ prefix for predict_step_end, but this may change soon. see here: https://github.com/PyTorchLightning/pytorch-lightning/issues/9380
+    # NOTE - PyTorch Lightning 1.5.1 still uses this on_ prefix for predict_step_end, but this may change soon. see here: https://github.com/PyTorchLightning/pytorch-lightning/issues/9380
     def on_predict_step_end(self, outputs: list) -> list:
         return outputs
 

--- a/sheepy/models/base_classifier.py
+++ b/sheepy/models/base_classifier.py
@@ -39,15 +39,14 @@ class BaseClassifier(pl.LightningModule):
 
     def _build_model(self):
         raise NotImplementedError(
-            "_build_model() has not been implemented. You must override this in your classifier")
+            "_build_model() has not been implemented. You must override this in your classifier"
+        )
 
     def _build_metrics(self) -> None:
         """Builds out the basic metrics for a classifier. This needs to be implemented in your classifier by
         instantiating the ClassificationMetrics class
         """
-        self.metrics = ClassificationMetrics(
-            self.data.label_encoder.vocab,
-            self.args.metrics)
+        self.metrics = ClassificationMetrics(self.data.label_encoder.vocab, self.args.metrics)
 
     def _get_class_weights(self):
         """
@@ -57,38 +56,40 @@ class BaseClassifier(pl.LightningModule):
         weights = [None] * self.data.label_encoder.vocab_size
 
         # Normalize the ratios
-        scale_factor = 1.0/sum(self.data.train_class_sizes.values())
+        scale_factor = 1.0 / sum(self.data.train_class_sizes.values())
         train_class_ratios = self.data.train_class_sizes
         for class_name, num_samples in self.data.train_class_sizes.items():
-            train_class_ratios[class_name] = num_samples*scale_factor
+            train_class_ratios[class_name] = num_samples * scale_factor
 
         # and now invert each value to get its weight
         for class_name, ratio in train_class_ratios.items():
             label_index = self.data.label_encoder.encode(class_name)
-            weights[label_index] = 1./ratio
+            weights[label_index] = 1.0 / ratio
 
         print("\nClass weights:\n{}".format(weights))
         return torch.tensor(weights)
 
     def _build_loss(self):
-        """ Initializes the loss function/s."""
+        """Initializes the loss function/s."""
         self.class_weights = self._get_class_weights()
         self._loss = torch.nn.CrossEntropyLoss(weight=self.class_weights)
 
     def configure_optimizers(self):
-        """ Sets different Learning rates for different parameter groups. """
+        """Sets different Learning rates for different parameter groups."""
         raise NotImplementedError(
-            "configure_optimizers() has not been implemented. You must override this in your classifier")
+            "configure_optimizers() has not been implemented. You must override this in your classifier"
+        )
 
     def forward(self, tokens, lengths) -> dict:
-        """ Usual pytorch forward function.
+        """Usual pytorch forward function.
         :param tokens: text sequences [batch_size x src_seq_len]
         :param lengths: source lengths [batch_size]
         Returns:
             Dictionary with model outputs (e.g: logits)
         """
         raise NotImplementedError(
-            "forward() has not been implemented. You must override this in your classifier")
+            "forward() has not been implemented. You must override this in your classifier"
+        )
 
     def loss(self, predictions: dict, targets: dict) -> torch.tensor:
         """
@@ -118,13 +119,15 @@ class BaseClassifier(pl.LightningModule):
         logits = model_out["logits"]
         labels = targets["labels"]
 
-        self.log('train/loss', loss_train, on_step=True, on_epoch=True, prog_bar=True, logger=True)
+        self.log("train/loss", loss_train, on_step=True, on_epoch=True, prog_bar=True, logger=True)
 
-        output = OrderedDict({
-            "loss": loss_train, #we would normally want to name this 'train/loss', but pytorch lightning wants it to be 'loss'
-            "logits": logits,
-            "target": labels,
-        })
+        output = OrderedDict(
+            {
+                "loss": loss_train,  # we would normally want to name this 'train/loss', but pytorch lightning wants it to be 'loss'
+                "logits": logits,
+                "target": labels,
+            }
+        )
 
         return output
 
@@ -138,8 +141,12 @@ class BaseClassifier(pl.LightningModule):
         Returns:
             None
         """
-        outputs['loss'] = outputs['loss'].sum() #To backpropagate, loss needs to be aggregated across GPUs
-        output_metrics = self.metrics.compute_metrics(outputs['logits'], outputs['target'], stage='train')
+        outputs["loss"] = outputs[
+            "loss"
+        ].sum()  # To backpropagate, loss needs to be aggregated across GPUs
+        output_metrics = self.metrics.compute_metrics(
+            outputs["logits"], outputs["target"], stage="train"
+        )
         self.log_dict(output_metrics, on_step=True, on_epoch=True)
         return outputs
 
@@ -180,7 +187,9 @@ class BaseClassifier(pl.LightningModule):
         Returns:
             None
         """
-        output_metrics = self.metrics.compute_metrics(outputs['logits'], outputs['target'], stage='val')
+        output_metrics = self.metrics.compute_metrics(
+            outputs["logits"], outputs["target"], stage="val"
+        )
         self.log_dict(output_metrics, on_step=False, on_epoch=True)
         return outputs
 
@@ -220,7 +229,9 @@ class BaseClassifier(pl.LightningModule):
             dict: [description]
         """
 
-        output_metrics = self.metrics.compute_metrics(outputs['logits'], outputs['target'], stage='test')
+        output_metrics = self.metrics.compute_metrics(
+            outputs["logits"], outputs["target"], stage="test"
+        )
         self.log_dict(output_metrics, on_step=False, on_epoch=True)
         return outputs
 
@@ -230,7 +241,7 @@ class BaseClassifier(pl.LightningModule):
         self.logger.experiment.log({"test/epoch_confusion_matrix": cm})
         return None
 
-    def predict_step(self, batch: tuple, batch_idx: int, dataloader_idx: int=0):
+    def predict_step(self, batch: tuple, batch_idx: int, dataloader_idx: int = 0):
         """PyTorch Lightning function to do raw batch prediction
 
         Args:
@@ -245,12 +256,14 @@ class BaseClassifier(pl.LightningModule):
         model_out = self.forward(**inputs)
         logits = model_out["logits"]
 
-        sample_ids = ids['sample_id_keys']
+        sample_ids = ids["sample_id_keys"]
 
-        output = OrderedDict({
-            "logits": logits,
-            "sample_id_keys": sample_ids,
-        })
+        output = OrderedDict(
+            {
+                "logits": logits,
+                "sample_id_keys": sample_ids,
+            }
+        )
 
         return output
 
@@ -265,7 +278,7 @@ class BaseClassifier(pl.LightningModule):
     def on_predict_step_end(self, outputs: list) -> list:
         return outputs
 
-    #NOTE - PyTorch Lightning 1.5.1 still uses this on_ prefix for predict_epoch_end, but this may change soon. see here: https://github.com/PyTorchLightning/pytorch-lightning/issues/9380
+    # NOTE - PyTorch Lightning 1.5.1 still uses this on_ prefix for predict_epoch_end, but this may change soon. see here: https://github.com/PyTorchLightning/pytorch-lightning/issues/9380
     def on_predict_epoch_end(self, outputs: List) -> dict:
         if self.live_eval_mode:
             prediction_logits = outputs[0][0]["logits"].cpu().squeeze()
@@ -296,27 +309,23 @@ class BaseClassifier(pl.LightningModule):
         labels = targets["labels"]
         logits = model_out["logits"]
 
-        loss_key = stage + '/loss'
-        output = OrderedDict({
-            loss_key: loss_val,
-            "logits": logits,
-            "target": labels
-        })
+        loss_key = stage + "/loss"
+        output = OrderedDict({loss_key: loss_val, "logits": logits, "target": labels})
 
         return output
 
-    #TODO - move this function to classification metrics?
+    # TODO - move this function to classification metrics?
     def _create_confusion_matrix(self, outputs: list, name="Confusion Matrix"):
-        logits = torch.cat([output['logits']
-                          for output in outputs]).detach().cpu()
+        logits = torch.cat([output["logits"] for output in outputs]).detach().cpu()
         pred = torch.argmax(logits, dim=1).numpy()
-        trg = torch.cat([output['target']
-                            for output in outputs]).detach().cpu().numpy()
+        trg = torch.cat([output["target"] for output in outputs]).detach().cpu().numpy()
 
-        cm = wandb.plot.confusion_matrix(y_true=pred, preds=trg, class_names=self.data.label_encoder.vocab)
+        cm = wandb.plot.confusion_matrix(
+            y_true=pred, preds=trg, class_names=self.data.label_encoder.vocab
+        )
         return cm
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
+        """Return the argument parser with necessary args for this class appended to it"""
         return parser

--- a/sheepy/models/inference.py
+++ b/sheepy/models/inference.py
@@ -3,7 +3,7 @@ import os
 
 import pandas as pd
 import torch
-from transformers import AutoModel, AutoModelForSequenceClassification, AutoTokenizer
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 
 class SequenceClassificationModelRunner:

--- a/sheepy/models/multiclass_transformer_classifier.py
+++ b/sheepy/models/multiclass_transformer_classifier.py
@@ -86,15 +86,6 @@ class MulticlassTransformerClassifier(TransformerClassifier):
 
         val_loss_mean /= len(outputs)
         val_acc_mean /= len(outputs)
-        tqdm_dict = {"val_loss": val_loss_mean, "val_acc": val_acc_mean}
-        result = {
-            "progress_bar": tqdm_dict,
-            "log": tqdm_dict,
-            "val_loss": val_loss_mean,
-            "f1": f1,
-            "precision": precision,
-            "recall": recall,
-        }
         tracked_metrics = {
             "val_loss": val_loss_mean,
             "val_acc": val_acc_mean,

--- a/sheepy/models/multiclass_transformer_classifier.py
+++ b/sheepy/models/multiclass_transformer_classifier.py
@@ -15,7 +15,9 @@ class MulticlassTransformerClassifier(TransformerClassifier):
 
     def __init__(self, args: Namespace, data: LightningDataModule, logger=None) -> None:
         super().__init__(args, data)
-        assert self.args.hparams['num_labels'] > 2, "The Config object sees num_labels expected to be 2. The multiclass classifier must use at least 3. If you have just two labels, use a base classifier"
+        assert (
+            self.args.hparams["num_labels"] > 2
+        ), "The Config object sees num_labels expected to be 2. The multiclass classifier must use at least 3. If you have just two labels, use a base classifier"
 
     def _build_metrics(self) -> None:
         """
@@ -23,14 +25,10 @@ class MulticlassTransformerClassifier(TransformerClassifier):
 
         Note this is just a small variation from the binary classifier where we kill off auroc
         """
-        self.metrics = {
-            'f1': f1_score,
-            'precision': precision_score,
-            'recall': recall_score
-        }
+        self.metrics = {"f1": f1_score, "precision": precision_score, "recall": recall_score}
 
     def validation_epoch_end(self, outputs: list) -> dict:
-        """ Function that takes as input a list of dictionaries returned by the validation_step
+        """Function that takes as input a list of dictionaries returned by the validation_step
         function and measures the model performance accross the entire validation set.
 
         A lot of this logic here defines what to do in the case of multiple GPU's. In this case,
@@ -48,24 +46,24 @@ class MulticlassTransformerClassifier(TransformerClassifier):
         val_loss_mean = 0
         val_acc_mean = 0
 
-        pred = torch.cat([output['pred']
-                          for output in outputs]).detach().cpu()
-        target = torch.cat([output['target']
-                            for output in outputs]).detach().cpu()
+        pred = torch.cat([output["pred"] for output in outputs]).detach().cpu()
+        target = torch.cat([output["target"] for output in outputs]).detach().cpu()
 
         # Set certain metric outputs to 0 if there are no positives.
-        total_positives = torch.sum(target).cpu().numpy(
-        ) if self.on_gpu else torch.sum(target).numpy()
+        total_positives = (
+            torch.sum(target).cpu().numpy() if self.on_gpu else torch.sum(target).numpy()
+        )
 
         if total_positives == 0:
             wandb.termwarn(
-                "Warning, no sample targets were found that are positive. Setting certain metrics to output 0.")
+                "Warning, no sample targets were found that are positive. Setting certain metrics to output 0."
+            )
             # 1 or 0 is standard. 0 is nice though because then you go up from the beginning :)
-            f1 = precision = recall = torch.tensor([0.])
+            f1 = precision = recall = torch.tensor([0.0])
         else:
-            f1 = self.metrics['f1'](target.numpy(), pred.numpy())
-            precision = self.metrics['precision'](target.numpy(), pred.numpy())
-            recall = self.metrics['recall'](target.numpy(), pred.numpy())
+            f1 = self.metrics["f1"](target.numpy(), pred.numpy())
+            precision = self.metrics["precision"](target.numpy(), pred.numpy())
+            recall = self.metrics["recall"](target.numpy(), pred.numpy())
 
         # The confusion matrix we can construct always, regardless of whether or not we have any positives
         cm = self._create_confusion_matrix(pred, target)
@@ -93,17 +91,17 @@ class MulticlassTransformerClassifier(TransformerClassifier):
             "progress_bar": tqdm_dict,
             "log": tqdm_dict,
             "val_loss": val_loss_mean,
-            'f1': f1,
-            'precision': precision,
-            'recall': recall
+            "f1": f1,
+            "precision": precision,
+            "recall": recall,
         }
         tracked_metrics = {
             "val_loss": val_loss_mean,
             "val_acc": val_acc_mean,
-            'f1': f1,
-            'precision': precision,
-            'recall': recall,
-            'cm': cm
+            "f1": f1,
+            "precision": precision,
+            "recall": recall,
+            "cm": cm,
         }
 
         self.log_metrics(tracked_metrics)

--- a/sheepy/models/multilabel_transformer_classifier.py
+++ b/sheepy/models/multilabel_transformer_classifier.py
@@ -12,5 +12,5 @@ class MultiLabelTransformerClassifier(MultiLabelBaseClassifier, TransformerClass
 
     @classmethod
     def add_model_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """ Return the argument parser with necessary args for this class appended to it """
+        """Return the argument parser with necessary args for this class appended to it"""
         return parser

--- a/sheepy/nlp/label_encoder.py
+++ b/sheepy/nlp/label_encoder.py
@@ -1,16 +1,18 @@
-import pandas as pd
-from torch import Tensor, transpose, tensor, stack, long
-from typing import List, Dict
+from typing import Dict, List
 
-class LabelEncoder():
-    def __init__(self, labels: List[str], multilabel: bool=False, unknown_label: str=None):
+import pandas as pd
+from torch import Tensor, long, stack, tensor, transpose
+
+
+class LabelEncoder:
+    def __init__(self, labels: List[str], multilabel: bool = False, unknown_label: str = None):
         self.multilabel = multilabel
         self.unknown_label = unknown_label
         self.vocab = labels
         self.labels_to_index = {val: idx for idx, val in enumerate(self.vocab)}
         self.index_to_labels = {idx: val for idx, val in enumerate(self.vocab)}
         self.vocab_size = len(self.vocab)
-    
+
     def encode(self, label_str: str) -> Tensor:
         """Given a single label, return a tensor of shape [1] containing the integer representation of the label
 
@@ -19,18 +21,22 @@ class LabelEncoder():
 
         Returns:
             Tensor: Single integer representation of the label
-        
+
         Raises:
             ValueError: label does not exist in the vocabulary and there is not an unknown_label argument set
         """
         if label_str not in self.labels_to_index:
             if self.unknown_label is None:
-                raise ValueError("No unknown label is set in LabelEncoder and came across unknown label {}".format(label_str))
+                raise ValueError(
+                    "No unknown label is set in LabelEncoder and came across unknown label {}".format(
+                        label_str
+                    )
+                )
             else:
                 return tensor(self.labels_to_index[self.unknown_label], dtype=long)
 
         return tensor(self.labels_to_index[label_str], dtype=long)
-    
+
     def batch_encode(self, label_strings: List[str]) -> Tensor:
         """Given a list of labels, return a tensor of shape [batch_size] containing the integer representation of the labels
 
@@ -39,14 +45,14 @@ class LabelEncoder():
 
         Returns:
             Tensor: 1D tensor of size batch_size, equal to len(label_str), with the integer representation of each label
-        
+
         Raises:
             ValueError: any of the labels do not exist in the vocabulary and there is not an unknown_label argument set
         """
         batch = [self.encode(label_str) for label_str in label_strings]
         return stack(batch, dim=0)
-    
-    #TODO - add support for unknown label?
+
+    # TODO - add support for unknown label?
     def batch_encode_multilabel(self, sample: Dict) -> Tensor:
         """Given a dictionary input that follows from the output of torch's collate_tensors function, create a single tensor that
         stores the labels for the label columns provided.
@@ -60,7 +66,7 @@ class LabelEncoder():
 
         Returns:
             Tensor: 2D float tensor of size batch_size x num_labels
-        
+
         Raises:
             ValueError: any of the labels do not exist in the vocabulary and there is not an unknown_label argument set
         """
@@ -85,7 +91,7 @@ class LabelEncoder():
         """
         label_int = label_tensor.squeeze().item()
         return self.index_to_labels[label_int]
-    
+
     def batch_decode(self, label_tensor: Tensor) -> List[str]:
         """Given a tensor with a multiple integer labels, return a tensor of shape [batch_size] containing the string representations of the labels
 
@@ -94,14 +100,14 @@ class LabelEncoder():
 
         Returns:
             List[str]: List of strings of length batch_size, equal to len(label_str), with the string representation of each label
-        
+
         Raises:
             ValueError: any label integer index does not exist in the vocabulary (is larger than vocab size) and there is not an unknown_label argument set
         """
         batch = [t.squeeze(0) for t in label_tensor.split(1, dim=0)]
         return [self.decode(label_int) for label_int in batch]
-    
-    #TODO - add support for unknown label?
+
+    # TODO - add support for unknown label?
     def batch_decode_multilabel(self, label_tensor: Tensor) -> Dict:
         """[summary]
 
@@ -123,31 +129,47 @@ class LabelEncoder():
         # # transpose gets us to (batch_size, num_labels)
         # labels = transpose(FloatTensor(outputs), 0, 1)
         # return labels
-    
+
     @classmethod
-    def initializeFromDataframe(cls, df: pd.DataFrame, label_col: str, reserved_labels: List[str] = [], unknown_label: str=None):
+    def initializeFromDataframe(
+        cls,
+        df: pd.DataFrame,
+        label_col: str,
+        reserved_labels: List[str] = [],
+        unknown_label: str = None,
+    ):
         labels_list = reserved_labels
         for found_label in df[label_col].unique().tolist():
             if found_label not in labels_list:
                 labels_list.append(found_label)
-        
+
         if unknown_label is not None and unknown_label not in labels_list:
             labels_list.append(unknown_label)
 
         print("creating label_list {}".format(labels_list))
         return cls(labels_list, multilabel=False, unknown_label=unknown_label)
-    
+
     @classmethod
-    def initializeFromMultilabelDataframe(cls, df: pd.DataFrame, label_list: List[str], reserved_labels: List[str] = [], unknown_label: str=None):
+    def initializeFromMultilabelDataframe(
+        cls,
+        df: pd.DataFrame,
+        label_list: List[str],
+        reserved_labels: List[str] = [],
+        unknown_label: str = None,
+    ):
         labels_list = reserved_labels
         for label in label_list:
             unique_vals = df[label].unique()
             if len(unique_vals) > 2:  # this restriction can probably be removed eventually
-                raise ValueError("Label {} must be binary. Instead, see values {}".format(label, str(unique_vals)))
+                raise ValueError(
+                    "Label {} must be binary. Instead, see values {}".format(
+                        label, str(unique_vals)
+                    )
+                )
             if label not in labels_list:
                 labels_list.append(label)
-        
+
         if unknown_label is not None and unknown_label not in labels_list:
             labels_list.append(unknown_label)
-        
+
         return cls(labels_list, multilabel=True, unknown_label=unknown_label)

--- a/sheepy/nlp/label_encoder.py
+++ b/sheepy/nlp/label_encoder.py
@@ -71,8 +71,8 @@ class LabelEncoder:
             ValueError: any of the labels do not exist in the vocabulary and there is not an unknown_label argument set
         """
         outputs = []
-        for l in self.vocab:
-            integerized_label = [int(i) for i in sample[l]]
+        for label in self.vocab:
+            integerized_label = [int(i) for i in sample[label]]
             outputs.append(integerized_label)
         outputs = tensor(outputs)
         # transpose gets us to (batch_size, num_labels)

--- a/sheepy/nlp/tokenizer.py
+++ b/sheepy/nlp/tokenizer.py
@@ -1,7 +1,8 @@
-import torch
-from transformers import AutoTokenizer
-from torchnlp.encoders.text.text_encoder import TextEncoder
 from typing import Tuple
+
+import torch
+from torchnlp.encoders.text.text_encoder import TextEncoder
+from transformers import AutoTokenizer
 
 
 class Tokenizer(TextEncoder):
@@ -19,22 +20,22 @@ class Tokenizer(TextEncoder):
 
     @property
     def unk_index(self) -> int:
-        """ Returns the index used for the unknown token. """
+        """Returns the index used for the unknown token."""
         return self.tokenizer.unk_token_id
 
     @property
     def bos_index(self) -> int:
-        """ Returns the index used for the begin-of-sentence token. """
+        """Returns the index used for the begin-of-sentence token."""
         return self.tokenizer.cls_token_id
 
     @property
     def eos_index(self) -> int:
-        """ Returns the index used for the end-of-sentence token. """
+        """Returns the index used for the end-of-sentence token."""
         return self.tokenizer.sep_token_id
 
     @property
     def pad_index(self) -> int:
-        """ Returns the index used for the padding token. """
+        """Returns the index used for the padding token."""
         return self.tokenizer.pad_token_id
 
     @property
@@ -54,7 +55,7 @@ class Tokenizer(TextEncoder):
         return len(self.itos)
 
     def encode(self, sequence: str) -> torch.Tensor:
-        """ Encodes a 'sequence'.
+        """Encodes a 'sequence'.
         Arguments:
             :param sequence: String 'sequence' to encode.
 
@@ -82,15 +83,14 @@ class Tokenizer(TextEncoder):
             return_token_type_ids=False,
             return_attention_mask=False,
             truncation="only_first",
-            max_length=512
+            max_length=512,
         )
         return tokenizer_output["input_ids"], tokenizer_output["length"]
 
 
-def mask_fill(fill_value: float,
-              tokens: torch.tensor,
-              embeddings: torch.tensor,
-              pad_index: int) -> torch.tensor:
+def mask_fill(
+    fill_value: float, tokens: torch.tensor, embeddings: torch.tensor, pad_index: int
+) -> torch.tensor:
     """
     Function that masks embeddings representing padded elements.
 

--- a/tests/common/test_collate.py
+++ b/tests/common/test_collate.py
@@ -10,16 +10,8 @@ from sheepy.nlp.tokenizer import Tokenizer
 @pytest.fixture
 def batch_sample() -> list:
     batch = [
-        {
-            'text': "first",
-            'label': 0,
-            'sample_id': 1
-        },
-        {
-            'text': "second",
-            'label': 1,
-            'sample_id': 2
-        }
+        {"text": "first", "label": 0, "sample_id": 1},
+        {"text": "second", "label": 1, "sample_id": 2},
     ]
     return batch
 
@@ -28,53 +20,40 @@ def batch_sample() -> list:
 def windowed_batch_sample() -> list:
     batch = [
         {
-            'text': "fourth",
-            'text_prev_1': 'third!',
-            'text_prev_2': 'second',
-            'text_prev_3': 'first',
-            'text_next_1': 'fifth',
-            'text_next_2': 'sixth',
-            'text_next_3': 'seventh',
-            'additional': 'tomato',
-            'additional2': 'floop',
-            'label': 0,
-            'sample_id': 1
+            "text": "fourth",
+            "text_prev_1": "third!",
+            "text_prev_2": "second",
+            "text_prev_3": "first",
+            "text_next_1": "fifth",
+            "text_next_2": "sixth",
+            "text_next_3": "seventh",
+            "additional": "tomato",
+            "additional2": "floop",
+            "label": 0,
+            "sample_id": 1,
         },
         {
-            'text': "fifth",
-            'text_prev_1': 'fourth',
-            'text_prev_2': 'third!',
-            'text_prev_3': 'second',
-            'text_next_1': 'sixth',
-            'text_next_2': 'seventh',
-            'text_next_3': 'eighth',
-            'additional': 'potato',
-            'additional2': 'bloop',
-            'label': 1,
-            'sample_id': 2
-        }
+            "text": "fifth",
+            "text_prev_1": "fourth",
+            "text_prev_2": "third!",
+            "text_prev_3": "second",
+            "text_next_1": "sixth",
+            "text_next_2": "seventh",
+            "text_next_3": "eighth",
+            "additional": "potato",
+            "additional2": "bloop",
+            "label": 1,
+            "sample_id": 2,
+        },
     ]
     return batch
+
 
 @pytest.fixture
 def multilabel_batch_sample() -> list:
     batch = [
-        {
-            'text': "first",
-            'label1': 0,
-            'label2': 0,
-            'label3': 0,
-            'label4': 0,
-            'sample_id': 1
-        },
-        {
-            'text': "second",
-            'label1': 0,
-            'label2': 1,
-            'label3': 0,
-            'label4': 1,
-            'sample_id': 2
-        }
+        {"text": "first", "label1": 0, "label2": 0, "label3": 0, "label4": 0, "sample_id": 1},
+        {"text": "second", "label1": 0, "label2": 1, "label3": 0, "label4": 1, "sample_id": 2},
     ]
     return batch
 
@@ -83,80 +62,81 @@ def multilabel_batch_sample() -> list:
 def multilabel_windowed_batch_sample() -> list:
     batch = [
         {
-            'text': "fourth",
-            'text_prev_1': 'third!',
-            'text_prev_2': 'second',
-            'text_prev_3': 'first',
-            'text_next_1': 'fifth',
-            'text_next_2': 'sixth',
-            'text_next_3': 'seventh',
-            'additional': 'tomato',
-            'additional2': 'floop',
-            'label1': 0,
-            'label2': 0,
-            'label3': 0,
-            'label4': 0,
-            'sample_id': 1
+            "text": "fourth",
+            "text_prev_1": "third!",
+            "text_prev_2": "second",
+            "text_prev_3": "first",
+            "text_next_1": "fifth",
+            "text_next_2": "sixth",
+            "text_next_3": "seventh",
+            "additional": "tomato",
+            "additional2": "floop",
+            "label1": 0,
+            "label2": 0,
+            "label3": 0,
+            "label4": 0,
+            "sample_id": 1,
         },
         {
-            'text': "fifth",
-            'text_prev_1': 'fourth',
-            'text_prev_2': 'third!',
-            'text_prev_3': 'second',
-            'text_next_1': 'sixth',
-            'text_next_2': 'seventh',
-            'text_next_3': 'eighth',
-            'additional': 'potato',
-            'additional2': 'bloop',
-            'label1': 0,
-            'label2': 1,
-            'label3': 0,
-            'label4': 1,
-            'sample_id': 2
-        }
+            "text": "fifth",
+            "text_prev_1": "fourth",
+            "text_prev_2": "third!",
+            "text_prev_3": "second",
+            "text_next_1": "sixth",
+            "text_next_2": "seventh",
+            "text_next_3": "eighth",
+            "additional": "potato",
+            "additional2": "bloop",
+            "label1": 0,
+            "label2": 1,
+            "label3": 0,
+            "label4": 1,
+            "sample_id": 2,
+        },
     ]
     return batch
+
 
 @pytest.fixture
 def sample_windowed_batch_sample() -> list:
     batch = [
         {
-            'text': "fourth",
-            'text_prev_1': 'third',
-            'text_prev_2': 'second',
-            'text_prev_3': 'first',
-            'text_next_1': 'fifth',
-            'text_next_2': 'sixth',
-            'text_next_3': 'seventh',
-            'label': 0,
-            'sample_id': 1
+            "text": "fourth",
+            "text_prev_1": "third",
+            "text_prev_2": "second",
+            "text_prev_3": "first",
+            "text_next_1": "fifth",
+            "text_next_2": "sixth",
+            "text_next_3": "seventh",
+            "label": 0,
+            "sample_id": 1,
         },
         {
-            'text': "fifth",
-            'text_prev_1': 'fourth',
-            'text_prev_2': 'third',
-            'text_prev_3': 'second',
-            'text_next_1': 'sixth',
-            'text_next_2': 'seventh',
-            'text_next_3': 'eighth',
-            'label': 0,
-            'sample_id': 2
-        }
+            "text": "fifth",
+            "text_prev_1": "fourth",
+            "text_prev_2": "third",
+            "text_prev_3": "second",
+            "text_next_1": "sixth",
+            "text_next_2": "seventh",
+            "text_next_3": "eighth",
+            "label": 0,
+            "sample_id": 2,
+        },
     ]
     return batch
 
+
 @pytest.fixture
 def label_encoder() -> LabelEncoder:
-    return LabelEncoder(
-        [0, 1],
-        unknown_label=None)
+    return LabelEncoder([0, 1], unknown_label=None)
+
 
 @pytest.fixture
 def multilabel_label_encoder() -> LabelEncoder:
     return LabelEncoder(
-        ["label1","label2","label3","label4"],
-        multilabel=True,
-        unknown_label=None)
+        ["label1", "label2", "label3", "label4"], multilabel=True, unknown_label=None
+    )
+
 
 @pytest.fixture
 def tokenizer() -> Tokenizer:
@@ -174,7 +154,7 @@ def collect_tensors(container) -> list:
         for val in container.values():
             collected += collect_tensors(val)
     else:
-        raise ValueError('unexpected value type {}'.format(type(container)))
+        raise ValueError("unexpected value type {}".format(type(container)))
     return collected
 
 
@@ -193,67 +173,84 @@ def collect_keys(container) -> list:
 def test_single_label_single_text_collate(batch_sample, tokenizer, label_encoder):
     collated = single_text_collate_function(
         batch_sample,
-        'text',
-        'label',
-        'sample_id',
+        "text",
+        "label",
+        "sample_id",
         tokenizer,
         label_encoder=label_encoder,
-        evaluate=False
+        evaluate=False,
     )
 
     tensors = collect_tensors(collated)
 
-    assert (len(tensors) == 3) #inputs tokens, input lengths, targets, no ids
-    assert (all(elem.shape[0] == len(batch_sample) for elem in iter(tensors)))
+    assert len(tensors) == 3  # inputs tokens, input lengths, targets, no ids
+    assert all(elem.shape[0] == len(batch_sample) for elem in iter(tensors))
 
-    #Test tokens match
-    assert torch.all(torch.eq(tensors[0][0], torch.Tensor([101,2034,102]))) #2034 = symbol for 'first'
-    assert torch.all(torch.eq(tensors[0][1], torch.Tensor([101,2117,102])))
+    # Test tokens match
+    assert torch.all(
+        torch.eq(tensors[0][0], torch.Tensor([101, 2034, 102]))
+    )  # 2034 = symbol for 'first'
+    assert torch.all(torch.eq(tensors[0][1], torch.Tensor([101, 2117, 102])))
 
-    #Test lengths match
-    assert torch.all(torch.eq(tensors[1], torch.Tensor([3,3])))
+    # Test lengths match
+    assert torch.all(torch.eq(tensors[1], torch.Tensor([3, 3])))
 
-    #Test labels match
-    assert torch.all(torch.eq(tensors[2], torch.Tensor([0,1])))
+    # Test labels match
+    assert torch.all(torch.eq(tensors[2], torch.Tensor([0, 1])))
 
 
-def test_multi_label_single_text_collate(multilabel_batch_sample, tokenizer, multilabel_label_encoder):
+def test_multi_label_single_text_collate(
+    multilabel_batch_sample, tokenizer, multilabel_label_encoder
+):
     collated = single_text_collate_function(
         multilabel_batch_sample,
-        'text',
-        ['label1','label2','label3','label4'],
-        'sample_id',
+        "text",
+        ["label1", "label2", "label3", "label4"],
+        "sample_id",
         tokenizer,
         label_encoder=multilabel_label_encoder,
-        evaluate=False
+        evaluate=False,
     )
 
     tensors = collect_tensors(collated)
 
-    assert (len(tensors) == 3) #inputs tokens, input lengths, targets, no ids
-    assert (all(elem.shape[0] == len(multilabel_batch_sample) for elem in iter(tensors)))
+    assert len(tensors) == 3  # inputs tokens, input lengths, targets, no ids
+    assert all(elem.shape[0] == len(multilabel_batch_sample) for elem in iter(tensors))
 
-    #Test tokens match
-    assert torch.all(torch.eq(tensors[0][0], torch.Tensor([101,2034,102]))) #2034 = symbol for 'first'
-    assert torch.all(torch.eq(tensors[0][1], torch.Tensor([101,2117,102])))
+    # Test tokens match
+    assert torch.all(
+        torch.eq(tensors[0][0], torch.Tensor([101, 2034, 102]))
+    )  # 2034 = symbol for 'first'
+    assert torch.all(torch.eq(tensors[0][1], torch.Tensor([101, 2117, 102])))
 
-    #Test lengths match
-    assert torch.all(torch.eq(tensors[1], torch.Tensor([3,3])))
+    # Test lengths match
+    assert torch.all(torch.eq(tensors[1], torch.Tensor([3, 3])))
 
-    #Test labels match
-    assert torch.all(torch.eq(tensors[2][0], torch.Tensor([0,0,0,0])))
-    assert torch.all(torch.eq(tensors[2][1], torch.Tensor([0,1,0,1])))
+    # Test labels match
+    assert torch.all(torch.eq(tensors[2][0], torch.Tensor([0, 0, 0, 0])))
+    assert torch.all(torch.eq(tensors[2][1], torch.Tensor([0, 1, 0, 1])))
+
 
 def test_concatenate_text_samples(windowed_batch_sample):
     collated = collate_tensors(windowed_batch_sample)
     concatenated = _concatenate_text_samples(
         collated,
-        ['text_prev_3', 'text_prev_2', 'text_prev_1', 'text', 'text_next_1', 'text_next_2', 'text_next_3'],
-        default_separator="."
+        [
+            "text_prev_3",
+            "text_prev_2",
+            "text_prev_1",
+            "text",
+            "text_next_1",
+            "text_next_2",
+            "text_next_3",
+        ],
+        default_separator=".",
     )
 
-    expected = ["first. second. third! fourth. fifth. sixth. seventh.",
-        "second. third! fourth. fifth. sixth. seventh. eighth."]
+    expected = [
+        "first. second. third! fourth. fifth. sixth. seventh.",
+        "second. third! fourth. fifth. sixth. seventh. eighth.",
+    ]
 
     assert concatenated[0] == expected[0]
     assert concatenated[1] == expected[1]

--- a/tests/common/test_df_ops.py
+++ b/tests/common/test_df_ops.py
@@ -10,100 +10,109 @@ from sheepy.common.df_ops import (
 
 
 def test_read_csv_text_classifier():
-    path = 'tests/resources/dummy_dataset.csv'
-    text_col = 'text'
-    label_col = 'label'
+    path = "tests/resources/dummy_dataset.csv"
+    text_col = "text"
+    label_col = "label"
 
-    with pytest.raises(ValueError, match=r'.*not a valid text column.*'):
-        read_csv_text_classifier(path, text_col='invalid', label_cols=label_col)
+    with pytest.raises(ValueError, match=r".*not a valid text column.*"):
+        read_csv_text_classifier(path, text_col="invalid", label_cols=label_col)
 
-    with pytest.raises(ValueError, match=r'.*not a valid label column.*'):
-        read_csv_text_classifier(path, text_col=text_col, label_cols='invalid')
+    with pytest.raises(ValueError, match=r".*not a valid label column.*"):
+        read_csv_text_classifier(path, text_col=text_col, label_cols="invalid")
 
-    df_evaluate = read_csv_text_classifier(path, text_col=text_col, label_cols='invalid', evaluate=True)
-    assert (SOURCE_FILE in df_evaluate.columns)
+    df_evaluate = read_csv_text_classifier(
+        path, text_col=text_col, label_cols="invalid", evaluate=True
+    )
+    assert SOURCE_FILE in df_evaluate.columns
 
     df_train = read_csv_text_classifier(path, text_col=text_col, label_cols=label_col)
-    assert (text_col in df_train.columns)
-    assert (label_col in df_train.columns)
-    assert (SOURCE_FILE not in df_train.columns)
+    assert text_col in df_train.columns
+    assert label_col in df_train.columns
+    assert SOURCE_FILE not in df_train.columns
+
 
 def test_read_csv():
-    path = 'tests/resources/dummy_dataset.csv'
-    text_col = 'text'
-    label_col = 'label'
+    path = "tests/resources/dummy_dataset.csv"
+    text_col = "text"
+    label_col = "label"
 
     df = read_csv(path)
-    assert (text_col in df.columns)
-    assert (SOURCE_FILE in df.columns)
-    assert (label_col in df.columns)
-    assert df.shape == (4,6)
+    assert text_col in df.columns
+    assert SOURCE_FILE in df.columns
+    assert label_col in df.columns
+    assert df.shape == (4, 6)
+
 
 def test_read_csv_with_filter():
-    path = 'tests/resources/dummy_dataset.csv'
-    text_col = 'text'
-    label_col = 'label'
+    path = "tests/resources/dummy_dataset.csv"
+    text_col = "text"
+    label_col = "label"
 
-    column_list = ['text','label']
+    column_list = ["text", "label"]
 
     df = read_csv(path, column_list)
-    assert (text_col in df.columns)
-    assert (SOURCE_FILE in df.columns)
-    assert (label_col in df.columns)
-    assert ('group_id' not in df.columns)
-    assert df.shape == (4,3)
+    assert text_col in df.columns
+    assert SOURCE_FILE in df.columns
+    assert label_col in df.columns
+    assert "group_id" not in df.columns
+    assert df.shape == (4, 3)
+
 
 def test_resample_positives():
-    path = 'tests/resources/dummy_dataset.csv'
-    text_col = 'text'
-    label_col = 'label'
-    pos_label = '1'
+    path = "tests/resources/dummy_dataset.csv"
+    text_col = "text"
+    label_col = "label"
+    pos_label = "1"
 
     df = read_csv_text_classifier(path, text_col=text_col, label_cols=label_col)
 
-    #Verify things are unmodified if resample rate is 1
+    # Verify things are unmodified if resample rate is 1
     resample_rate = 1
     resampled_1_df = resample_positives(df, resample_rate, label_col, pos_label, reshuffle=False)
-    assert df.shape==resampled_1_df.shape
-    assert df[df[label_col]==pos_label].shape == resampled_1_df[resampled_1_df[label_col]==pos_label].shape
+    assert df.shape == resampled_1_df.shape
+    assert (
+        df[df[label_col] == pos_label].shape
+        == resampled_1_df[resampled_1_df[label_col] == pos_label].shape
+    )
 
-    #Verify correct number of rows and correct rows added if not equal to one
+    # Verify correct number of rows and correct rows added if not equal to one
     resample_rate = 3
     resampled_3_df = resample_positives(df, resample_rate, label_col, pos_label, reshuffle=False)
-    assert df.shape[1]==resampled_3_df.shape[1]
-    assert df[df[label_col]==pos_label].shape[0] * 3 == resampled_3_df[resampled_3_df[label_col]==pos_label].shape[0]
-    assert df[df[label_col]!=pos_label].shape == resampled_3_df[resampled_3_df[label_col]!=pos_label].shape
+    assert df.shape[1] == resampled_3_df.shape[1]
+    assert (
+        df[df[label_col] == pos_label].shape[0] * 3
+        == resampled_3_df[resampled_3_df[label_col] == pos_label].shape[0]
+    )
+    assert (
+        df[df[label_col] != pos_label].shape
+        == resampled_3_df[resampled_3_df[label_col] != pos_label].shape
+    )
+
 
 def test_resample_positives_multilabel():
-    path = 'tests/resources/dummy_dataset_multilabel.csv'
-    text_col = 'text'
-    text_id_col = 'text_id'
-    label_cols = ['label1', 'label2', 'label3']
-    pos_label = '1'
+    path = "tests/resources/dummy_dataset_multilabel.csv"
+    text_col = "text"
+    text_id_col = "text_id"
+    label_cols = ["label1", "label2", "label3"]
+    pos_label = "1"
 
-    df = read_csv_text_classifier(path, text_col=text_col, label_cols=label_cols, additional_cols=['text_id'])
+    df = read_csv_text_classifier(
+        path, text_col=text_col, label_cols=label_cols, additional_cols=["text_id"]
+    )
 
-    resample_rate_dict = {
-        'label1': 1,
-        'label2': 1,
-        'label3': 1
-    }
+    resample_rate_dict = {"label1": 1, "label2": 1, "label3": 1}
 
-    #Verify things are unmodified if resample rate is 1
+    # Verify things are unmodified if resample rate is 1
     rdf = resample_multilabel_positives(df, resample_rate_dict, pos_label, reshuffle=False)
-    assert df.shape==rdf.shape
+    assert df.shape == rdf.shape
 
-    #Verify correct number of rows and correct rows added if a single is not equal to one
-    resample_rate_dict = {
-        'label1': 1,
-        'label2': 1,
-        'label3': 4
-    }
+    # Verify correct number of rows and correct rows added if a single is not equal to one
+    resample_rate_dict = {"label1": 1, "label2": 1, "label3": 4}
     rdf = resample_multilabel_positives(df, resample_rate_dict, pos_label, reshuffle=False)
     assert rdf.shape[0] == 17
-    assert df.shape[1]==rdf.shape[1]
+    assert df.shape[1] == rdf.shape[1]
 
-    #Heres the original dataframe
+    # Heres the original dataframe
     # ,group_id,text_id,text,label1,label2,label3
     # 0,123,123_0,This conference will now be recorded.,0,0,0
     # 1,123,123_1,potato,1,0,1
@@ -111,7 +120,7 @@ def test_resample_positives_multilabel():
     # 3,123,123_3,the end of all things potato,0,0,1
     # 4,123,123_4,final potato,1,1,1
 
-    #Rows to be added for label1: 4
+    # Rows to be added for label1: 4
     # 5,123,123_1,potato,1,0,1
     # 6,123,123_2," potato but in quotes",0,1,1
     # 7,123,123_3,the end of all things potato,0,0,1
@@ -124,21 +133,17 @@ def test_resample_positives_multilabel():
     # 14,123,123_2," potato but in quotes",0,1,1
     # 15,123,123_3,the end of all things potato,0,0,1
     # 16,123,123_4,final potato,1,1,1
-    #Check each text id individually for how many copies it should have
-    assert rdf[rdf[text_id_col]=='123_0'].shape[0] == 1
-    assert rdf[rdf[text_id_col]=='123_1'].shape[0] == 4
-    assert rdf[rdf[text_id_col]=='123_2'].shape[0] == 4
-    assert rdf[rdf[text_id_col]=='123_3'].shape[0] == 4
-    assert rdf[rdf[text_id_col]=='123_4'].shape[0] == 4
+    # Check each text id individually for how many copies it should have
+    assert rdf[rdf[text_id_col] == "123_0"].shape[0] == 1
+    assert rdf[rdf[text_id_col] == "123_1"].shape[0] == 4
+    assert rdf[rdf[text_id_col] == "123_2"].shape[0] == 4
+    assert rdf[rdf[text_id_col] == "123_3"].shape[0] == 4
+    assert rdf[rdf[text_id_col] == "123_4"].shape[0] == 4
 
-    #Verify correct number of rows and correct rows added if multiple are unequal to 1
-    resample_rate_dict = {
-        'label1': 2,
-        'label2': 2,
-        'label3': 3
-    }
+    # Verify correct number of rows and correct rows added if multiple are unequal to 1
+    resample_rate_dict = {"label1": 2, "label2": 2, "label3": 3}
 
-    #Heres the original dataframe
+    # Heres the original dataframe
     # ,group_id,text_id,text,label1,label2,label3
     # 0,123,123_0,This conference will now be recorded.,0,0,0
     # 1,123,123_1,potato,1,0,1
@@ -146,15 +151,15 @@ def test_resample_positives_multilabel():
     # 3,123,123_3,the end of all things potato,0,0,1
     # 4,123,123_4,final potato,1,1,1
 
-    #Rows to be added for label1: 2
+    # Rows to be added for label1: 2
     # 5,123,123_1,potato,1,0,1
     # 6,123,123_4,final potato,1,1,1
 
-    #Rows to be added for label2: 2
+    # Rows to be added for label2: 2
     # 7,123,123_2," potato but in quotes",0,1,1
     # 8,123,123_4,final potato,1,1,1
 
-    #Rows to be added for label3: 3
+    # Rows to be added for label3: 3
     # 9,123,123_1,potato,1,0,1
     # 10,123,123_2," potato but in quotes",0,1,1
     # 11,123,123_3,the end of all things potato,0,0,1
@@ -165,8 +170,8 @@ def test_resample_positives_multilabel():
     # 16,123,123_4,final potato,1,1,1
 
     rdf = resample_multilabel_positives(df, resample_rate_dict, pos_label, reshuffle=False)
-    assert df.shape[1]==rdf.shape[1]
-    assert rdf.shape[0]==17
+    assert df.shape[1] == rdf.shape[1]
+    assert rdf.shape[0] == 17
 
     # #Check each text id individually for how many copies it should have
     # assert rdf[rdf['text_id']=='123_0'].shape[0] == 1
@@ -175,8 +180,8 @@ def test_resample_positives_multilabel():
     # assert rdf[rdf['text_id']=='123_3'].shape[0] == 3
     # assert rdf[rdf['text_id']=='123_4'].shape[0] == 5
 
-    assert rdf[rdf[text_id_col]=='123_0'].shape[0] == 1
-    assert rdf[rdf[text_id_col]=='123_1'].shape[0] == 4
-    assert rdf[rdf[text_id_col]=='123_2'].shape[0] == 4
-    assert rdf[rdf[text_id_col]=='123_3'].shape[0] == 3
-    assert rdf[rdf[text_id_col]=='123_4'].shape[0] == 5
+    assert rdf[rdf[text_id_col] == "123_0"].shape[0] == 1
+    assert rdf[rdf[text_id_col] == "123_1"].shape[0] == 4
+    assert rdf[rdf[text_id_col] == "123_2"].shape[0] == 4
+    assert rdf[rdf[text_id_col] == "123_3"].shape[0] == 3
+    assert rdf[rdf[text_id_col] == "123_4"].shape[0] == 5

--- a/tests/nlp/test_label_encoder.py
+++ b/tests/nlp/test_label_encoder.py
@@ -7,51 +7,96 @@ from sheepy.nlp.label_encoder import LabelEncoder
 
 @pytest.fixture
 def binary_label_encoder() -> LabelEncoder:
-    d = {'num_purchases': [5, 10, 15, 20, 25, 30, 35], 'label': ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"]}
+    d = {
+        "num_purchases": [5, 10, 15, 20, 25, 30, 35],
+        "label": ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"],
+    }
     df = DataFrame(data=d)
     encoder = LabelEncoder.initializeFromDataframe(df, label_col="label")
     return encoder
 
+
 @pytest.fixture
 def binary_label_encoder_unknown_exists() -> LabelEncoder:
-    d = {'num_purchases': [5, 10, 15, 20, 25, 30, 35], 'label': ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"]}
+    d = {
+        "num_purchases": [5, 10, 15, 20, 25, 30, 35],
+        "label": ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"],
+    }
     df = DataFrame(data=d)
     encoder = LabelEncoder.initializeFromDataframe(df, label_col="label", unknown_label="apple")
     return encoder
 
+
 @pytest.fixture
 def binary_label_encoder_unknown_does_not_exist() -> LabelEncoder:
-    d = {'num_purchases': [5, 10, 15, 20, 25, 30, 35], 'label': ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"]}
+    d = {
+        "num_purchases": [5, 10, 15, 20, 25, 30, 35],
+        "label": ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"],
+    }
     df = DataFrame(data=d)
     encoder = LabelEncoder.initializeFromDataframe(df, label_col="label", unknown_label="unknown")
     return encoder
 
+
 @pytest.fixture
 def binary_label_encoder_reserved_vocab() -> LabelEncoder:
-    d = {'num_purchases': [5, 10, 15, 20, 25, 30, 35], 'label': ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"]}
+    d = {
+        "num_purchases": [5, 10, 15, 20, 25, 30, 35],
+        "label": ["apple", "banana", "orange", "apple", "apple", "strawberry", "pear"],
+    }
     df = DataFrame(data=d)
-    encoder = LabelEncoder.initializeFromDataframe(df, label_col="label", reserved_labels=["reserved1", "reserved2"], unknown_label="unknown")
+    encoder = LabelEncoder.initializeFromDataframe(
+        df, label_col="label", reserved_labels=["reserved1", "reserved2"], unknown_label="unknown"
+    )
     return encoder
 
-#Test the single label factory functions
+
+# Test the single label factory functions
 def test_binary_label_encoder_vocab(binary_label_encoder):
     assert binary_label_encoder.vocab == ["apple", "banana", "orange", "strawberry", "pear"]
     assert binary_label_encoder.vocab_size == 5
 
+
 def test_binary_label_encoder_unknown_vocab_exists(binary_label_encoder_unknown_exists):
-    assert binary_label_encoder_unknown_exists.vocab == ["apple", "banana", "orange", "strawberry", "pear"]
+    assert binary_label_encoder_unknown_exists.vocab == [
+        "apple",
+        "banana",
+        "orange",
+        "strawberry",
+        "pear",
+    ]
     assert binary_label_encoder_unknown_exists.vocab_size == 5
 
-def test_binary_label_encoder_unknown_vocab_does_not_exist(binary_label_encoder_unknown_does_not_exist):
-    assert binary_label_encoder_unknown_does_not_exist.vocab == ["apple", "banana", "orange", "strawberry", "pear", "unknown"]
+
+def test_binary_label_encoder_unknown_vocab_does_not_exist(
+    binary_label_encoder_unknown_does_not_exist,
+):
+    assert binary_label_encoder_unknown_does_not_exist.vocab == [
+        "apple",
+        "banana",
+        "orange",
+        "strawberry",
+        "pear",
+        "unknown",
+    ]
     assert binary_label_encoder_unknown_does_not_exist.vocab_size == 6
 
+
 def test_binary_label_encoder_reserved_vocab(binary_label_encoder_reserved_vocab):
-    assert binary_label_encoder_reserved_vocab.vocab == ["reserved1", "reserved2", "apple", "banana", "orange", "strawberry", "pear", "unknown"]
+    assert binary_label_encoder_reserved_vocab.vocab == [
+        "reserved1",
+        "reserved2",
+        "apple",
+        "banana",
+        "orange",
+        "strawberry",
+        "pear",
+        "unknown",
+    ]
     assert binary_label_encoder_reserved_vocab.vocab_size == 8
 
 
-#Test the single label encoder functions
+# Test the single label encoder functions
 def test_binary_label_encoder_batch_encodes(binary_label_encoder):
     test_strs = ["banana", "banana", "pear", "apple"]
 
@@ -61,35 +106,45 @@ def test_binary_label_encoder_batch_encodes(binary_label_encoder):
     assert torch.equal(out, expected)
 
 
-def test_binary_label_encoder_batch_encodes_with_unknown_exists(binary_label_encoder_unknown_exists):
+def test_binary_label_encoder_batch_encodes_with_unknown_exists(
+    binary_label_encoder_unknown_exists,
+):
     test_strs = ["banana", "banana", "pear", "this_is_unknown", "apple"]
 
     expected = torch.tensor([1, 1, 4, 0, 0], dtype=torch.long)
     out = binary_label_encoder_unknown_exists.batch_encode(test_strs)
 
-    assert torch.equal(out,expected)
+    assert torch.equal(out, expected)
 
-def test_binary_label_encoder_batch_encodes_with_unknown_does_not_exist(binary_label_encoder_unknown_does_not_exist):
+
+def test_binary_label_encoder_batch_encodes_with_unknown_does_not_exist(
+    binary_label_encoder_unknown_does_not_exist,
+):
     test_strs = ["banana", "banana", "pear", "this_is_unknown", "apple"]
 
     expected = torch.tensor([1, 1, 4, 5, 0], dtype=torch.long)
     out = binary_label_encoder_unknown_does_not_exist.batch_encode(test_strs)
 
-    assert torch.equal(out,expected)
+    assert torch.equal(out, expected)
 
-#Test the single label decoder functions
+
+# Test the single label decoder functions
 def test_binary_label_encoder_batch_decodes(binary_label_encoder):
     expected = ["banana", "banana", "pear", "apple"]
     test_encoded = torch.tensor([1, 1, 4, 0], dtype=torch.long)
     out = binary_label_encoder.batch_decode(test_encoded)
 
-    assert expected==out
+    assert expected == out
 
-def test_binary_label_encoder_batch_decodes_with_unknown_does_not_exist(binary_label_encoder_unknown_does_not_exist):
+
+def test_binary_label_encoder_batch_decodes_with_unknown_does_not_exist(
+    binary_label_encoder_unknown_does_not_exist,
+):
     expected = ["banana", "banana", "pear", "unknown", "apple"]
     test_encoded = torch.tensor([1, 1, 4, 5, 0], dtype=torch.long)
     out = binary_label_encoder_unknown_does_not_exist.batch_decode(test_encoded)
 
-    assert expected==out
+    assert expected == out
 
-#TODO - test some encoder->decoder->recover original
+
+# TODO - test some encoder->decoder->recover original


### PR DESCRIPTION
fixes #…

## Why?

We want to make sure we follow standard formatting and linting rules.

### before

We are not always following standard formatting, have errors in the type hints, non-standard import sorting etc.

### after

Now, we
- Add a pre-commit config and can run it via `pre-commit run -a`
- Fix the linting errors for `black`, `flake8`, `isort`, and `secrets`
- Still need to fix `mypy` errors https://github.com/robmsylvester/sheepy/issues/10
