### PR TITLE
Sanity check

### DIFF
--- a/examples/config/config_guide.json
+++ b/examples/config/config_guide.json
@@ -22,7 +22,7 @@
         "batch_size": "int, batch size for training",
         "dense_layer_scale_factor": "float, scale factor from FC layer n to FC layer n+1",
         "save_epoch_count": "int, only now used in image model. controls minimum epoch number to start saving",
-        "num_epochs": "int, number of training epochs",
+        "max_epochs": "int, number of training epochs",
         "num_epochs_decay": "int, number of epochs to start decaying learning rate",
         "accumulate_grad_batches": "int, number of batches to run to accumulate gradients. 1 is safe",
         "gradient_clip_val": "int, l2-norm gradient max clip to control stability. 1 is good. maybe 2 or 3 but no higher usually",

--- a/examples/config/config_semeval.json
+++ b/examples/config/config_semeval.json
@@ -48,7 +48,7 @@
         "encoder_model": "google/bert_uncased_L-2_H-128_A-2",
         "batch_size": 32,
         "save_epoch_count": 4,
-        "num_epochs": 3,
+        "max_epochs": 3,
         "num_epochs_decay": 100,
         "accumulate_grad_batches": 1,
         "gradient_clip_val": 1,

--- a/examples/config/config_sms_spam.json
+++ b/examples/config/config_sms_spam.json
@@ -45,7 +45,7 @@
         "n_next_text_samples_sample_size": 4,
         "batch_size": 16,
         "save_epoch_count": 4,
-        "num_epochs": 6,
+        "max_epochs": 6,
         "num_epochs_decay": 100,
         "accumulate_grad_batches": 1,
         "gradient_clip_val": 1,

--- a/examples/config/config_toxic_comments.json
+++ b/examples/config/config_toxic_comments.json
@@ -58,7 +58,7 @@
         "context_labels": "remove",
         "batch_size": 32,
         "save_epoch_count": 4,
-        "num_epochs": 10,
+        "max_epochs": 10,
         "num_epochs_decay": 100,
         "accumulate_grad_batches": 1,
         "gradient_clip_val": 1,


### PR DESCRIPTION
fixes #…

## Why?

We want to be able to sanity check trained models easily.

### before

We only had metrics and could check outputs manually.

### after

Now, we 
- Write validation and test samples consisting of inputs, predictions and labels to a CSV file
- Add the ability to disable logging (e.g. for debugging)
- Add an `entity` parameter to send experiment tracking logs to a shared organization
- Slightly refactor writing of confusion matrix
